### PR TITLE
Expose TLS settings for backends and HTTPS listeners

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -41,8 +41,8 @@
 		},
 		{
 			"ImportPath": "github.com/mailgun/manners",
-			"Comment": "0.3.1-12-g69a4adc",
-			"Rev": "69a4adcf8fc04e8aef0ed5f9e43982739220ed8f"
+			"Comment": "0.3.1-18-g97d9cc9",
+			"Rev": "97d9cc9efd89bbbdab17f92386b65bfb377e10b3"
 		},
 		{
 			"ImportPath": "github.com/mailgun/metrics",
@@ -58,39 +58,39 @@
 		},
 		{
 			"ImportPath": "github.com/mailgun/oxy/cbreaker",
-			"Rev": "3f326de5f0b9617793d5739973f32bd21252da61"
+			"Rev": "3fc5acbe278c4dea6012dfc5101a00a59f79802d"
 		},
 		{
 			"ImportPath": "github.com/mailgun/oxy/connlimit",
-			"Rev": "3f326de5f0b9617793d5739973f32bd21252da61"
+			"Rev": "3fc5acbe278c4dea6012dfc5101a00a59f79802d"
 		},
 		{
 			"ImportPath": "github.com/mailgun/oxy/forward",
-			"Rev": "3f326de5f0b9617793d5739973f32bd21252da61"
+			"Rev": "3fc5acbe278c4dea6012dfc5101a00a59f79802d"
 		},
 		{
 			"ImportPath": "github.com/mailgun/oxy/memmetrics",
-			"Rev": "3f326de5f0b9617793d5739973f32bd21252da61"
+			"Rev": "3fc5acbe278c4dea6012dfc5101a00a59f79802d"
 		},
 		{
 			"ImportPath": "github.com/mailgun/oxy/ratelimit",
-			"Rev": "3f326de5f0b9617793d5739973f32bd21252da61"
+			"Rev": "3fc5acbe278c4dea6012dfc5101a00a59f79802d"
 		},
 		{
 			"ImportPath": "github.com/mailgun/oxy/roundrobin",
-			"Rev": "3f326de5f0b9617793d5739973f32bd21252da61"
+			"Rev": "3fc5acbe278c4dea6012dfc5101a00a59f79802d"
 		},
 		{
 			"ImportPath": "github.com/mailgun/oxy/stream",
-			"Rev": "3f326de5f0b9617793d5739973f32bd21252da61"
+			"Rev": "3fc5acbe278c4dea6012dfc5101a00a59f79802d"
 		},
 		{
 			"ImportPath": "github.com/mailgun/oxy/testutils",
-			"Rev": "3f326de5f0b9617793d5739973f32bd21252da61"
+			"Rev": "3fc5acbe278c4dea6012dfc5101a00a59f79802d"
 		},
 		{
 			"ImportPath": "github.com/mailgun/oxy/utils",
-			"Rev": "3f326de5f0b9617793d5739973f32bd21252da61"
+			"Rev": "3fc5acbe278c4dea6012dfc5101a00a59f79802d"
 		},
 		{
 			"ImportPath": "github.com/mailgun/predicate",

--- a/Godeps/_workspace/src/github.com/mailgun/manners/server.go
+++ b/Godeps/_workspace/src/github.com/mailgun/manners/server.go
@@ -230,7 +230,9 @@ func (s *GracefulServer) Serve(listener net.Listener) error {
 
 	orgConnState := s.Server.ConnState
 	s.ConnState = func(conn net.Conn, newState http.ConnState) {
-		gconn := conn.(*gracefulConn)
+		// Ugly hack, but it works. We pass the information about the underlying state via the only available interface in net.Conn
+		// we do this not to override the tls.Conn, as the internal logic of http.Server depends on the type assertion (unfortunately)
+		gconn := conn.LocalAddr().(*gracefulAddr).gconn
 		switch newState {
 		case http.StateNew:
 			// new_conn -> StateNew

--- a/Godeps/_workspace/src/github.com/mailgun/oxy/forward/fwd.go
+++ b/Godeps/_workspace/src/github.com/mailgun/oxy/forward/fwd.go
@@ -91,8 +91,17 @@ func (f *Forwarder) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	f.log.Infof("Got response from %v, code: %v, duration: %v",
-		req.URL, response.StatusCode, time.Now().UTC().Sub(start))
+	if req.TLS != nil {
+		f.log.Infof("Round trip: %v, code: %v, duration: %v tls:version: %x, tls:resume:%t, tls:csuite:%x, tls:server:%v",
+			req.URL, response.StatusCode, time.Now().UTC().Sub(start),
+			req.TLS.Version,
+			req.TLS.DidResume,
+			req.TLS.CipherSuite,
+			req.TLS.ServerName)
+	} else {
+		f.log.Infof("Round trip: %v, code: %v, duration: %v",
+			req.URL, response.StatusCode, time.Now().UTC().Sub(start))
+	}
 
 	utils.CopyHeaders(w.Header(), response.Header)
 	w.WriteHeader(response.StatusCode)

--- a/Godeps/_workspace/src/github.com/mailgun/oxy/forward/fwd_test.go
+++ b/Godeps/_workspace/src/github.com/mailgun/oxy/forward/fwd_test.go
@@ -232,7 +232,10 @@ func (s *FwdSuite) TestForwardedProto(c *C) {
 	})
 	defer srv.Close()
 
-	f, err := New()
+	buf := &bytes.Buffer{}
+	l := utils.NewFileLogger(buf, utils.INFO)
+
+	f, err := New(Logger(l))
 	c.Assert(err, IsNil)
 
 	proxy := http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
@@ -247,6 +250,8 @@ func (s *FwdSuite) TestForwardedProto(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(re.StatusCode, Equals, http.StatusOK)
 	c.Assert(proto, Equals, "https")
+
+	c.Assert(strings.Contains(buf.String(), "tls"), Equals, true)
 }
 
 func (s *FwdSuite) TestChunkedResponseConversion(c *C) {

--- a/Godeps/_workspace/src/github.com/mailgun/oxy/stream/stream.go
+++ b/Godeps/_workspace/src/github.com/mailgun/oxy/stream/stream.go
@@ -285,6 +285,8 @@ func (s *Streamer) copyRequest(req *http.Request, body io.ReadCloser, bodySize i
 	o.TransferEncoding = []string{}
 	// http.Transport will close the request body on any error, we are controlling the close process ourselves, so we override the closer here
 	o.Body = ioutil.NopCloser(body)
+	// Preserve TLS state if it's present
+	o.TLS = req.TLS
 	return &o
 }
 

--- a/engine/etcdng/etcd_test.go
+++ b/engine/etcdng/etcd_test.go
@@ -123,6 +123,10 @@ func (s *EtcdSuite) TestListenerCRUD(c *C) {
 	s.suite.ListenerCRUD(c)
 }
 
+func (s *EtcdSuite) TestListenerSettingsCRUD(c *C) {
+	s.suite.ListenerSettingsCRUD(c)
+}
+
 func (s *EtcdSuite) TestBackendCRUD(c *C) {
 	s.suite.BackendCRUD(c)
 }

--- a/engine/json.go
+++ b/engine/json.go
@@ -54,6 +54,18 @@ type RawMiddleware struct {
 	Middleware json.RawMessage
 }
 
+type rawListener struct {
+	Id       string
+	Protocol string
+	Address  Address
+	Scope    string
+	Settings json.RawMessage
+}
+
+type rawListenerSettings struct {
+	TLS json.RawMessage
+}
+
 func HostsFromJSON(in []byte) ([]Host, error) {
 	var hs rawHosts
 	err := json.Unmarshal(in, &hs)
@@ -103,15 +115,21 @@ func HostFromJSON(in []byte, name ...string) (*Host, error) {
 }
 
 func ListenerFromJSON(in []byte, id ...string) (*Listener, error) {
-	var l *Listener
-	err := json.Unmarshal(in, &l)
+	var rl *rawListener
+	err := json.Unmarshal(in, &rl)
 	if err != nil {
 		return nil, err
 	}
 	if len(id) != 0 {
-		l.Id = id[0]
+		rl.Id = id[0]
 	}
-	return NewListener(l.Id, l.Protocol, l.Address.Network, l.Address.Address, l.Scope)
+	var settings interface{}
+	if rl.Protocol == HTTPS && len(rl.Settings) != 0 {
+		if settings, err = HTTPSListenerSettingsFromJSON(rl.Settings); err != nil {
+			return nil, err
+		}
+	}
+	return NewListener(rl.Id, rl.Protocol, rl.Address.Network, rl.Address.Address, rl.Scope, settings)
 }
 
 func ListenersFromJSON(in []byte) ([]Listener, error) {
@@ -227,6 +245,11 @@ func BackendFromJSON(in []byte, id ...string) (*Backend, error) {
 			return nil, err
 		}
 	}
+	if s.TLS != nil {
+		if _, err := NewTLSConfig(s.TLS); err != nil {
+			return nil, err
+		}
+	}
 	if len(id) != 0 {
 		rb.Id = id[0]
 	}
@@ -286,4 +309,29 @@ func ServerFromJSON(in []byte, id ...string) (*Server, error) {
 		e.Id = id[0]
 	}
 	return NewServer(e.Id, e.URL)
+}
+
+func HTTPSListenerSettingsFromJSON(in []byte) (*HTTPSListenerSettings, error) {
+	var rs *rawListenerSettings
+	if err := json.Unmarshal(in, &rs); err != nil {
+		return nil, err
+	}
+	s, err := TLSSettingsFromJSON(rs.TLS)
+	if err != nil {
+		return nil, err
+	}
+	return &HTTPSListenerSettings{
+		TLS: *s,
+	}, nil
+}
+
+func TLSSettingsFromJSON(in []byte) (*TLSSettings, error) {
+	var s *TLSSettings
+	if err := json.Unmarshal(in, &s); err != nil {
+		return nil, err
+	}
+	if _, err := NewTLSConfig(s); err != nil {
+		return nil, err
+	}
+	return s, nil
 }

--- a/engine/memng/mem_test.go
+++ b/engine/memng/mem_test.go
@@ -57,6 +57,10 @@ func (s *MemSuite) TestListenerCRUD(c *C) {
 	s.suite.ListenerCRUD(c)
 }
 
+func (s *MemSuite) TestListenerSettingsCRUD(c *C) {
+	s.suite.ListenerSettingsCRUD(c)
+}
+
 func (s *MemSuite) TestBackendCRUD(c *C) {
 	s.suite.BackendCRUD(c)
 }

--- a/engine/model.go
+++ b/engine/model.go
@@ -75,6 +75,22 @@ type Listener struct {
 	Address Address
 	// Scope is optional expression that limits the operational scope of this listener
 	Scope string
+	// Settings provides listener-type specific settings, e.g. TLS settings for HTTPS listener
+	Settings interface{} `json:",omitempty"`
+}
+
+func (l *Listener) TLSConfig() (*tls.Config, error) {
+	if l.Protocol != HTTPS {
+		return nil, fmt.Errorf("wrong listener proto: %v", l.Protocol)
+	}
+	if l.Settings == nil {
+		return NewTLSConfig(&TLSSettings{})
+	}
+	t, ok := l.Settings.(*HTTPSListenerSettings)
+	if !ok {
+		return nil, fmt.Errorf("expected *HTTPSListenerSettings, got %T", l.Settings)
+	}
+	return NewTLSConfig(&t.TLS)
 }
 
 func (l *Listener) String() string {
@@ -83,6 +99,28 @@ func (l *Listener) String() string {
 
 func (a *Address) Equals(o Address) bool {
 	return a.Network == o.Network && a.Address == o.Address
+}
+
+func (l *Listener) SettingsEquals(o *Listener) bool {
+	if l.Settings == nil && o.Settings == nil {
+		return true
+	}
+	ls, ok := l.Settings.(*HTTPSListenerSettings)
+	if !ok {
+		return false
+	}
+	os, ok := o.Settings.(*HTTPSListenerSettings)
+	if !ok {
+		return false
+	}
+	if (ls == nil && os != nil) || (ls != nil && os == nil) {
+		return false
+	}
+	return (&os.TLS).Equals(&ls.TLS)
+}
+
+type HTTPSListenerSettings struct {
+	TLS TLSSettings
 }
 
 // Sets up OCSP stapling, see http://en.wikipedia.org/wiki/OCSP_stapling
@@ -212,7 +250,7 @@ func NewAddress(network, address string) (*Address, error) {
 	return &Address{Network: network, Address: address}, nil
 }
 
-func NewListener(id, protocol, network, address, scope string) (*Listener, error) {
+func NewListener(id, protocol, network, address, scope string, settings interface{}) (*Listener, error) {
 	protocol = strings.ToLower(protocol)
 	if protocol != HTTP && protocol != HTTPS {
 		return nil, fmt.Errorf("unsupported protocol '%s', supported protocols are http and https", protocol)
@@ -234,6 +272,7 @@ func NewListener(id, protocol, network, address, scope string) (*Listener, error
 		Id:       id,
 		Address:  *a,
 		Protocol: protocol,
+		Settings: settings,
 	}, nil
 }
 
@@ -301,9 +340,12 @@ type HTTPBackendKeepAlive struct {
 }
 
 type HTTPBackendSettings struct {
+	// Timeouts provides timeout settings for backend servers
 	Timeouts HTTPBackendTimeouts
-	// Controls KeepAlive settins for backend servers
+	// KeepAlive controls keep-alive settings for backend servers
 	KeepAlive HTTPBackendKeepAlive
+	// TLS provides optional TLS settings for HTTP backend
+	TLS *TLSSettings `json:",omitempty"`
 }
 
 func (s *HTTPBackendSettings) Equals(o HTTPBackendSettings) bool {
@@ -311,7 +353,9 @@ func (s *HTTPBackendSettings) Equals(o HTTPBackendSettings) bool {
 		s.Timeouts.Dial == o.Timeouts.Dial &&
 		s.Timeouts.TLSHandshake == o.Timeouts.TLSHandshake &&
 		s.KeepAlive.Period == o.KeepAlive.Period &&
-		s.KeepAlive.MaxIdleConnsPerHost == o.KeepAlive.MaxIdleConnsPerHost)
+		s.KeepAlive.MaxIdleConnsPerHost == o.KeepAlive.MaxIdleConnsPerHost &&
+		((s.TLS == nil && o.TLS == nil) ||
+			((s.TLS != nil && o.TLS != nil) && s.TLS.Equals(o.TLS))))
 }
 
 type MiddlewareKey struct {
@@ -399,6 +443,14 @@ func transportSettings(s HTTPBackendSettings) (*TransportSettings, error) {
 		}
 	}
 	t.KeepAlive.MaxIdleConnsPerHost = s.KeepAlive.MaxIdleConnsPerHost
+
+	if s.TLS != nil {
+		config, err := NewTLSConfig(s.TLS)
+		if err != nil {
+			return nil, err
+		}
+		t.TLS = config
+	}
 	return t, nil
 }
 
@@ -667,4 +719,5 @@ type TransportKeepAlive struct {
 type TransportSettings struct {
 	Timeouts  TransportTimeouts
 	KeepAlive TransportKeepAlive
+	TLS       *tls.Config
 }

--- a/engine/model_test.go
+++ b/engine/model_test.go
@@ -246,6 +246,12 @@ func (s *BackendSuite) TestListenerSettingsEq(c *C) {
 			e: true,
 			c: "different https",
 		},
+		{
+			a: Listener{Settings: &HTTPSListenerSettings{TLS: TLSSettings{SessionTicketsDisabled: true}}},
+			b: Listener{Settings: &HTTPSListenerSettings{TLS: TLSSettings{}}},
+			e: false,
+			c: "session tickets",
+		},
 	}
 	for _, o := range options {
 		c.Assert((&o.a).SettingsEquals(&o.b), Equals, o.e, Commentf("TC: %v", o.c))
@@ -414,16 +420,20 @@ func (s *BackendSuite) TestNewTLSSettings(c *C) {
 				CipherSuites: []string{
 					"TLS_RSA_WITH_RC4_128_SHA",
 					"TLS_RSA_WITH_3DES_EDE_CBC_SHA",
+
 					"TLS_ECDHE_ECDSA_WITH_RC4_128_SHA",
 					"TLS_ECDHE_RSA_WITH_RC4_128_SHA",
 					"TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA",
 
 					"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
 					"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+
 					"TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA",
 					"TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA",
+
 					"TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA",
 					"TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA",
+
 					"TLS_RSA_WITH_AES_256_CBC_SHA",
 					"TLS_RSA_WITH_AES_128_CBC_SHA",
 				},
@@ -446,6 +456,7 @@ func (s *BackendSuite) TestNewTLSSettings(c *C) {
 				CipherSuites: []uint16{
 					tls.TLS_RSA_WITH_RC4_128_SHA,
 					tls.TLS_RSA_WITH_3DES_EDE_CBC_SHA,
+
 					tls.TLS_ECDHE_ECDSA_WITH_RC4_128_SHA,
 					tls.TLS_ECDHE_RSA_WITH_RC4_128_SHA,
 					tls.TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA,
@@ -464,6 +475,8 @@ func (s *BackendSuite) TestNewTLSSettings(c *C) {
 				},
 
 				InsecureSkipVerify: false,
+
+				ClientSessionCache: tls.NewLRUClientSessionCache(12),
 			},
 		},
 		{

--- a/engine/tls.go
+++ b/engine/tls.go
@@ -25,7 +25,16 @@ type TLSSettings struct {
 	// SessionCache specifies TLS session cache, default it 'LRU' with capacity 1024
 	SessionCache TLSSessionCache
 
-	// Preferred CipherSuites, default is
+	// Preferred CipherSuites, default is:
+	//
+	// TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+	// TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+	// TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA
+	// TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA
+	// TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA
+	// TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA
+	// TLS_RSA_WITH_AES_256_CBC_SHA
+	// TLS_RSA_WITH_AES_128_CBC_SHA
 	CipherSuites []string
 }
 
@@ -113,7 +122,7 @@ func NewTLSSessionCache(s *TLSSessionCache) (tls.ClientSessionCache, error) {
 	if cacheType == "" {
 		cacheType = LRUCacheType
 	}
-	if cacheType != "LRU" {
+	if cacheType != LRUCacheType {
 		return nil, fmt.Errorf("unsupported session cache type: %v", s.Type)
 	}
 	var capacity int

--- a/engine/tls.go
+++ b/engine/tls.go
@@ -1,0 +1,234 @@
+package engine
+
+import (
+	"crypto/tls"
+	"fmt"
+)
+
+// TLSSettings is a JSON and API friendly version of some of the tls.Config parameters
+type TLSSettings struct {
+	// PreferServerCipherSuites controls whether the server selects the CipherSuites
+	PreferServerCipherSuites bool
+
+	// SkipVerify skips certificate check, very insecure
+	InsecureSkipVerify bool
+
+	// MinVersion is minimal TLS version "VersionTLS10" is default
+	MinVersion string
+
+	// MaxVersion is max supported TLS version, "VersionTLS12" is default
+	MaxVersion string
+
+	// SessionTicketsDisabled disables session ticket resumption support
+	SessionTicketsDisabled bool
+
+	// SessionCache specifies TLS session cache, default it 'LRU' with capacity 1024
+	SessionCache TLSSessionCache
+
+	// Preferred CipherSuites, default is
+	CipherSuites []string
+}
+
+// TLSSessionCache sets up parameters for TLS session cache
+type TLSSessionCache struct {
+	// Session cache implementation, default is 'LRU' with capacity 1024
+	Type     string
+	Settings *LRUSessionCacheSettings
+}
+
+type LRUSessionCacheSettings struct {
+	// LRU Capacity default is 1024
+	Capacity int
+}
+
+// NewTLSConfig validates the TLSSettings and returns the tls.Config with the converted parameters
+func NewTLSConfig(s *TLSSettings) (*tls.Config, error) {
+	// Parse min and max TLS versions
+	var min, max uint16
+	var err error
+
+	if s.MinVersion == "" {
+		min = tls.VersionTLS10
+	} else if min, err = ParseTLSVersion(s.MinVersion); err != nil {
+		return nil, err
+	}
+
+	if s.MaxVersion == "" {
+		max = tls.VersionTLS12
+	} else if max, err = ParseTLSVersion(s.MaxVersion); err != nil {
+		return nil, err
+	}
+
+	var css []uint16
+	if len(s.CipherSuites) == 0 {
+		css = []uint16{
+			tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+			tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+
+			tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
+			tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
+
+			tls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
+			tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
+
+			tls.TLS_RSA_WITH_AES_256_CBC_SHA,
+			tls.TLS_RSA_WITH_AES_128_CBC_SHA,
+		}
+	} else {
+		css = make([]uint16, len(s.CipherSuites))
+		for i, suite := range s.CipherSuites {
+			cs, err := ParseCipherSuite(suite)
+			if err != nil {
+				return nil, err
+			}
+			css[i] = cs
+		}
+	}
+
+	var cache tls.ClientSessionCache
+	if !s.SessionTicketsDisabled {
+		cache, err = NewTLSSessionCache(&s.SessionCache)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &tls.Config{
+		MinVersion: min,
+		MaxVersion: max,
+
+		SessionTicketsDisabled: s.SessionTicketsDisabled,
+		ClientSessionCache:     cache,
+
+		PreferServerCipherSuites: s.PreferServerCipherSuites,
+		CipherSuites:             css,
+
+		InsecureSkipVerify: s.InsecureSkipVerify,
+	}, nil
+}
+
+// NewTLSSessionCache validates parameters and creates a new TLS session cache
+func NewTLSSessionCache(s *TLSSessionCache) (tls.ClientSessionCache, error) {
+	cacheType := s.Type
+	if cacheType == "" {
+		cacheType = LRUCacheType
+	}
+	if cacheType != "LRU" {
+		return nil, fmt.Errorf("unsupported session cache type: %v", s.Type)
+	}
+	var capacity int
+	if params := s.Settings; params != nil {
+		if params.Capacity < 0 {
+			return nil, fmt.Errorf("bad LRU capacity: %v", params.Capacity)
+		} else if params.Capacity == 0 {
+			capacity = DefaultLRUCapacity
+		} else {
+			capacity = params.Capacity
+		}
+	}
+	return tls.NewLRUClientSessionCache(capacity), nil
+}
+
+func ParseCipherSuite(cs string) (uint16, error) {
+	switch cs {
+	case "TLS_RSA_WITH_RC4_128_SHA":
+		return tls.TLS_RSA_WITH_RC4_128_SHA, nil
+	case "TLS_RSA_WITH_3DES_EDE_CBC_SHA":
+		return tls.TLS_RSA_WITH_3DES_EDE_CBC_SHA, nil
+	case "TLS_RSA_WITH_AES_128_CBC_SHA":
+		return tls.TLS_RSA_WITH_AES_128_CBC_SHA, nil
+	case "TLS_RSA_WITH_AES_256_CBC_SHA":
+		return tls.TLS_RSA_WITH_AES_256_CBC_SHA, nil
+	case "TLS_ECDHE_ECDSA_WITH_RC4_128_SHA":
+		return tls.TLS_ECDHE_ECDSA_WITH_RC4_128_SHA, nil
+	case "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA":
+		return tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA, nil
+	case "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA":
+		return tls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA, nil
+	case "TLS_ECDHE_RSA_WITH_RC4_128_SHA":
+		return tls.TLS_ECDHE_RSA_WITH_RC4_128_SHA, nil
+	case "TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA":
+		return tls.TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA, nil
+	case "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA":
+		return tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA, nil
+	case "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA":
+		return tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA, nil
+	case "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256":
+		return tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256, nil
+	case "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256":
+		return tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256, nil
+	}
+	return 0, fmt.Errorf("unsupported cipher suite: %v", cs)
+}
+
+func ParseTLSVersion(version string) (uint16, error) {
+	switch version {
+	case "VersionTLS10":
+		return tls.VersionTLS10, nil
+	case "VersionTLS11":
+		return tls.VersionTLS11, nil
+	case "VersionTLS12":
+		return tls.VersionTLS12, nil
+	}
+	return 0, fmt.Errorf("unsupported TLS version: %v", version)
+}
+
+const DefaultLRUCapacity = 1024
+const LRUCacheType = "LRU"
+
+func (s *TLSSettings) Equals(other *TLSSettings) bool {
+	scfg, err := NewTLSConfig(s)
+	if err != nil {
+		return false
+	}
+
+	ocfg, err := NewTLSConfig(other)
+	if err != nil {
+		return false
+	}
+
+	if scfg.PreferServerCipherSuites != ocfg.PreferServerCipherSuites ||
+		scfg.InsecureSkipVerify != ocfg.InsecureSkipVerify ||
+		scfg.MinVersion != ocfg.MinVersion ||
+		scfg.MaxVersion != ocfg.MaxVersion ||
+		scfg.SessionTicketsDisabled != ocfg.SessionTicketsDisabled {
+		return false
+	}
+
+	if len(scfg.CipherSuites) != len(ocfg.CipherSuites) {
+		return false
+	}
+
+	for i := range scfg.CipherSuites {
+		if scfg.CipherSuites[i] != ocfg.CipherSuites[i] {
+			return false
+		}
+	}
+	if !(&s.SessionCache).Equals(&other.SessionCache) {
+		return false
+	}
+
+	return true
+}
+
+func (c *TLSSessionCache) Equals(o *TLSSessionCache) bool {
+	if c.Type != o.Type {
+		return false
+	}
+
+	if c.Settings == nil && o.Settings == nil {
+		return true
+	}
+
+	cs, os := c.Settings, o.Settings
+
+	if (cs == nil && os != nil) || (cs != nil && os == nil) {
+		return false
+	}
+
+	if cs == nil && os == nil {
+		return true
+	}
+
+	return cs.Capacity == os.Capacity
+}

--- a/proxy/backend.go
+++ b/proxy/backend.go
@@ -69,6 +69,7 @@ func (b *backend) updateSettings(be engine.Backend) error {
 		return err
 	}
 	t := newTransport(s)
+
 	b.transport.CloseIdleConnections()
 	b.transport = t
 	for _, f := range b.frontends {
@@ -130,5 +131,6 @@ func newTransport(s *engine.TransportSettings) *http.Transport {
 		ResponseHeaderTimeout: s.Timeouts.Read,
 		TLSHandshakeTimeout:   s.Timeouts.TLSHandshake,
 		MaxIdleConnsPerHost:   s.KeepAlive.MaxIdleConnsPerHost,
+		TLSClientConfig:       s.TLS,
 	}
 }

--- a/proxy/backend.go
+++ b/proxy/backend.go
@@ -69,7 +69,6 @@ func (b *backend) updateSettings(be engine.Backend) error {
 		return err
 	}
 	t := newTransport(s)
-
 	b.transport.CloseIdleConnections()
 	b.transport = t
 	for _, f := range b.frontends {

--- a/proxy/mux.go
+++ b/proxy/mux.go
@@ -417,7 +417,7 @@ func (m *mux) upsertFrontend(fe engine.Frontend) (*frontend, error) {
 }
 
 func (m *mux) DeleteFrontend(fk engine.FrontendKey) error {
-	log.Infof("%v DeleteFrontend %v, %v", m, &fk)
+	log.Infof("%v DeleteFrontend %v", m, &fk)
 
 	m.mtx.Lock()
 	defer m.mtx.Unlock()

--- a/systest/systest_test.go
+++ b/systest/systest_test.go
@@ -275,7 +275,7 @@ func (s *VESuite) TestHTTPListenerCRUD(c *C) {
 
 	// Add HTTP listener
 	l1 := "l1"
-	listener, err := engine.NewListener(l1, "http", "tcp", "localhost:31000", "")
+	listener, err := engine.NewListener(l1, "http", "tcp", "localhost:31000", "", nil)
 	c.Assert(err, IsNil)
 	bytes, err := json.Marshal(listener)
 	c.Assert(err, IsNil)
@@ -327,7 +327,7 @@ func (s *VESuite) TestHTTPSListenerCRUD(c *C) {
 
 	// Add HTTPS listener
 	l2 := "ls2"
-	listener, err := engine.NewListener(l2, "https", "tcp", "localhost:32000", "")
+	listener, err := engine.NewListener(l2, "https", "tcp", "localhost:32000", "", nil)
 	c.Assert(err, IsNil)
 	bytes, err = json.Marshal(listener)
 	c.Assert(err, IsNil)
@@ -467,7 +467,7 @@ func (s *VESuite) TestLiveBinaryUpgrade(c *C) {
 
 	// Add HTTPS listener
 	l2 := "ls2"
-	listener, err := engine.NewListener(l2, "https", "tcp", "localhost:32000", "")
+	listener, err := engine.NewListener(l2, "https", "tcp", "localhost:32000", "", nil)
 	c.Assert(err, IsNil)
 	bytes, err = json.Marshal(listener)
 	c.Assert(err, IsNil)

--- a/testutils/testutils.go
+++ b/testutils/testutils.go
@@ -100,7 +100,7 @@ func MakeHost(name string, keyPair *engine.KeyPair) engine.Host {
 }
 
 func MakeListener(addr string, protocol string) engine.Listener {
-	l, err := engine.NewListener(UID("listener"), protocol, engine.TCP, addr, "")
+	l, err := engine.NewListener(UID("listener"), protocol, engine.TCP, addr, "", nil)
 	if err != nil {
 		panic(err)
 	}

--- a/vctl/command/backend.go
+++ b/vctl/command/backend.go
@@ -14,9 +14,10 @@ func NewBackendCommand(cmd *Command) cli.Command {
 				Name:   "upsert",
 				Usage:  "Update or insert a new backend to vulcan",
 				Action: cmd.upsertBackendAction,
-				Flags: append([]cli.Flag{
+				Flags: append(append([]cli.Flag{
 					cli.StringFlag{Name: "id", Usage: "backend id"}},
 					backendOptions()...),
+					getTLSFlags()...),
 			},
 			{
 				Name:   "rm",
@@ -99,6 +100,11 @@ func getBackendSettings(c *cli.Context) (engine.HTTPBackendSettings, error) {
 	s.KeepAlive.Period = c.Duration("keepAlivePeriod").String()
 	s.KeepAlive.MaxIdleConnsPerHost = c.Int("maxIdleConns")
 
+	tlsSettings, err := getTLSSettings(c)
+	if err != nil {
+		return s, err
+	}
+	s.TLS = tlsSettings
 	return s, nil
 }
 

--- a/vctl/command/listener.go
+++ b/vctl/command/listener.go
@@ -49,7 +49,7 @@ func NewListenerCommand(cmd *Command) cli.Command {
 }
 
 func (cmd *Command) upsertListenerAction(c *cli.Context) {
-	var settings interface{}
+	var settings *engine.HTTPSListenerSettings
 	if c.String("proto") == engine.HTTPS {
 		s, err := getTLSSettings(c)
 		if err != nil {

--- a/vctl/command/listener.go
+++ b/vctl/command/listener.go
@@ -27,13 +27,13 @@ func NewListenerCommand(cmd *Command) cli.Command {
 			{
 				Name:  "upsert",
 				Usage: "Update or insert a listener",
-				Flags: []cli.Flag{
+				Flags: append([]cli.Flag{
 					cli.StringFlag{Name: "id", Usage: "id"},
 					cli.StringFlag{Name: "proto", Usage: "protocol, either http or https"},
 					cli.StringFlag{Name: "net", Value: "tcp", Usage: "network, tcp or unix"},
 					cli.StringFlag{Name: "addr", Value: "tcp", Usage: "address to bind to, e.g. 'localhost:31000'"},
 					cli.StringFlag{Name: "scope", Usage: "scope expression limits the listener, e.g. 'Hostname(`myhost`)'"},
-				},
+				}, getTLSFlags()...),
 				Action: cmd.upsertListenerAction,
 			},
 			{
@@ -49,7 +49,16 @@ func NewListenerCommand(cmd *Command) cli.Command {
 }
 
 func (cmd *Command) upsertListenerAction(c *cli.Context) {
-	listener, err := engine.NewListener(c.String("id"), c.String("proto"), c.String("net"), c.String("addr"), c.String("scope"))
+	var settings interface{}
+	if c.String("proto") == engine.HTTPS {
+		s, err := getTLSSettings(c)
+		if err != nil {
+			cmd.printError(err)
+			return
+		}
+		settings = &engine.HTTPSListenerSettings{TLS: *s}
+	}
+	listener, err := engine.NewListener(c.String("id"), c.String("proto"), c.String("net"), c.String("addr"), c.String("scope"), settings)
 	if err != nil {
 		cmd.printError(err)
 		return

--- a/vctl/command/tls.go
+++ b/vctl/command/tls.go
@@ -1,0 +1,40 @@
+package command
+
+import (
+	"github.com/mailgun/vulcand/Godeps/_workspace/src/github.com/codegangsta/cli"
+	"github.com/mailgun/vulcand/engine"
+)
+
+func getTLSFlags() []cli.Flag {
+	return []cli.Flag{
+		cli.BoolFlag{Name: "tlsSkipVerify", Usage: "insecure: skip certificate verification"},
+		cli.BoolFlag{Name: "tlsPreferServerCS", Usage: "prefer server cipher suites, recommended on for listener settings"},
+		cli.BoolFlag{Name: "tlsSessionTicketsOff", Usage: "turns off TLS session tickets"},
+		cli.StringFlag{Name: "tlsMinV", Usage: "minimum supported TLS version"},
+		cli.StringFlag{Name: "tlsMaxV", Usage: "maximum supported TLS version"},
+		cli.StringFlag{Name: "tlsSessionCache", Usage: "session cache type"},
+		cli.IntFlag{Name: "tlsSessionCacheCapacity", Usage: "session cache capacity"},
+		cli.StringSliceFlag{Name: "tlsCS", Usage: "optional list of preferred cipher suites", Value: &cli.StringSlice{}},
+	}
+}
+
+func getTLSSettings(c *cli.Context) (*engine.TLSSettings, error) {
+	s := &engine.TLSSettings{
+		InsecureSkipVerify:       c.Bool("tlsSkipVerify"),
+		PreferServerCipherSuites: c.Bool("tlsPreferServerCS"),
+		SessionTicketsDisabled:   c.Bool("tlsSessionTicketsOff"),
+		MinVersion:               c.String("tlsMinV"),
+		MaxVersion:               c.String("tlsMaxV"),
+		CipherSuites:             c.StringSlice("tlsCS"),
+	}
+	s.SessionCache.Type = c.String("tlsSessionCache")
+	if s.SessionCache.Type == engine.LRUCacheType {
+		s.SessionCache.Settings = &engine.LRUSessionCacheSettings{
+			Capacity: c.Int("tlsSessionCacheCapacity"),
+		}
+	}
+	if _, err := engine.NewTLSConfig(s); err != nil {
+		return nil, err
+	}
+	return s, nil
+}


### PR DESCRIPTION
Purpose
-----------
Provide more configuration options for TLS, such as cipher suites, supported versions, session tickets and skipping certificate checks.

Implementation
--------------------
This commit exposes TLS settings for backends and HTTPS listeners via API, etcd and CLI interfaces.

Fixes
-------
