### PR TITLE
Add trace plugin

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -58,43 +58,43 @@
 		},
 		{
 			"ImportPath": "github.com/mailgun/oxy/cbreaker",
-			"Rev": "519803a84411272a05b0b0c01f50682432adac18"
+			"Rev": "421238106c2bb1364e51d60d5ea358fda42dc859"
 		},
 		{
 			"ImportPath": "github.com/mailgun/oxy/connlimit",
-			"Rev": "519803a84411272a05b0b0c01f50682432adac18"
+			"Rev": "421238106c2bb1364e51d60d5ea358fda42dc859"
 		},
 		{
 			"ImportPath": "github.com/mailgun/oxy/forward",
-			"Rev": "519803a84411272a05b0b0c01f50682432adac18"
+			"Rev": "421238106c2bb1364e51d60d5ea358fda42dc859"
 		},
 		{
 			"ImportPath": "github.com/mailgun/oxy/memmetrics",
-			"Rev": "519803a84411272a05b0b0c01f50682432adac18"
+			"Rev": "421238106c2bb1364e51d60d5ea358fda42dc859"
 		},
 		{
 			"ImportPath": "github.com/mailgun/oxy/ratelimit",
-			"Rev": "519803a84411272a05b0b0c01f50682432adac18"
+			"Rev": "421238106c2bb1364e51d60d5ea358fda42dc859"
 		},
 		{
 			"ImportPath": "github.com/mailgun/oxy/roundrobin",
-			"Rev": "519803a84411272a05b0b0c01f50682432adac18"
+			"Rev": "421238106c2bb1364e51d60d5ea358fda42dc859"
 		},
 		{
 			"ImportPath": "github.com/mailgun/oxy/stream",
-			"Rev": "519803a84411272a05b0b0c01f50682432adac18"
+			"Rev": "421238106c2bb1364e51d60d5ea358fda42dc859"
 		},
 		{
 			"ImportPath": "github.com/mailgun/oxy/testutils",
-			"Rev": "519803a84411272a05b0b0c01f50682432adac18"
+			"Rev": "421238106c2bb1364e51d60d5ea358fda42dc859"
 		},
 		{
 			"ImportPath": "github.com/mailgun/oxy/trace",
-			"Rev": "519803a84411272a05b0b0c01f50682432adac18"
+			"Rev": "421238106c2bb1364e51d60d5ea358fda42dc859"
 		},
 		{
 			"ImportPath": "github.com/mailgun/oxy/utils",
-			"Rev": "519803a84411272a05b0b0c01f50682432adac18"
+			"Rev": "421238106c2bb1364e51d60d5ea358fda42dc859"
 		},
 		{
 			"ImportPath": "github.com/mailgun/predicate",

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -58,43 +58,43 @@
 		},
 		{
 			"ImportPath": "github.com/mailgun/oxy/cbreaker",
-			"Rev": "421238106c2bb1364e51d60d5ea358fda42dc859"
+			"Rev": "cd4cb5405d92ccc36eafa2537dedfe051fe54557"
 		},
 		{
 			"ImportPath": "github.com/mailgun/oxy/connlimit",
-			"Rev": "421238106c2bb1364e51d60d5ea358fda42dc859"
+			"Rev": "cd4cb5405d92ccc36eafa2537dedfe051fe54557"
 		},
 		{
 			"ImportPath": "github.com/mailgun/oxy/forward",
-			"Rev": "421238106c2bb1364e51d60d5ea358fda42dc859"
+			"Rev": "cd4cb5405d92ccc36eafa2537dedfe051fe54557"
 		},
 		{
 			"ImportPath": "github.com/mailgun/oxy/memmetrics",
-			"Rev": "421238106c2bb1364e51d60d5ea358fda42dc859"
+			"Rev": "cd4cb5405d92ccc36eafa2537dedfe051fe54557"
 		},
 		{
 			"ImportPath": "github.com/mailgun/oxy/ratelimit",
-			"Rev": "421238106c2bb1364e51d60d5ea358fda42dc859"
+			"Rev": "cd4cb5405d92ccc36eafa2537dedfe051fe54557"
 		},
 		{
 			"ImportPath": "github.com/mailgun/oxy/roundrobin",
-			"Rev": "421238106c2bb1364e51d60d5ea358fda42dc859"
+			"Rev": "cd4cb5405d92ccc36eafa2537dedfe051fe54557"
 		},
 		{
 			"ImportPath": "github.com/mailgun/oxy/stream",
-			"Rev": "421238106c2bb1364e51d60d5ea358fda42dc859"
+			"Rev": "cd4cb5405d92ccc36eafa2537dedfe051fe54557"
 		},
 		{
 			"ImportPath": "github.com/mailgun/oxy/testutils",
-			"Rev": "421238106c2bb1364e51d60d5ea358fda42dc859"
+			"Rev": "cd4cb5405d92ccc36eafa2537dedfe051fe54557"
 		},
 		{
 			"ImportPath": "github.com/mailgun/oxy/trace",
-			"Rev": "421238106c2bb1364e51d60d5ea358fda42dc859"
+			"Rev": "cd4cb5405d92ccc36eafa2537dedfe051fe54557"
 		},
 		{
 			"ImportPath": "github.com/mailgun/oxy/utils",
-			"Rev": "421238106c2bb1364e51d60d5ea358fda42dc859"
+			"Rev": "cd4cb5405d92ccc36eafa2537dedfe051fe54557"
 		},
 		{
 			"ImportPath": "github.com/mailgun/predicate",

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -58,39 +58,43 @@
 		},
 		{
 			"ImportPath": "github.com/mailgun/oxy/cbreaker",
-			"Rev": "3fc5acbe278c4dea6012dfc5101a00a59f79802d"
+			"Rev": "519803a84411272a05b0b0c01f50682432adac18"
 		},
 		{
 			"ImportPath": "github.com/mailgun/oxy/connlimit",
-			"Rev": "3fc5acbe278c4dea6012dfc5101a00a59f79802d"
+			"Rev": "519803a84411272a05b0b0c01f50682432adac18"
 		},
 		{
 			"ImportPath": "github.com/mailgun/oxy/forward",
-			"Rev": "3fc5acbe278c4dea6012dfc5101a00a59f79802d"
+			"Rev": "519803a84411272a05b0b0c01f50682432adac18"
 		},
 		{
 			"ImportPath": "github.com/mailgun/oxy/memmetrics",
-			"Rev": "3fc5acbe278c4dea6012dfc5101a00a59f79802d"
+			"Rev": "519803a84411272a05b0b0c01f50682432adac18"
 		},
 		{
 			"ImportPath": "github.com/mailgun/oxy/ratelimit",
-			"Rev": "3fc5acbe278c4dea6012dfc5101a00a59f79802d"
+			"Rev": "519803a84411272a05b0b0c01f50682432adac18"
 		},
 		{
 			"ImportPath": "github.com/mailgun/oxy/roundrobin",
-			"Rev": "3fc5acbe278c4dea6012dfc5101a00a59f79802d"
+			"Rev": "519803a84411272a05b0b0c01f50682432adac18"
 		},
 		{
 			"ImportPath": "github.com/mailgun/oxy/stream",
-			"Rev": "3fc5acbe278c4dea6012dfc5101a00a59f79802d"
+			"Rev": "519803a84411272a05b0b0c01f50682432adac18"
 		},
 		{
 			"ImportPath": "github.com/mailgun/oxy/testutils",
-			"Rev": "3fc5acbe278c4dea6012dfc5101a00a59f79802d"
+			"Rev": "519803a84411272a05b0b0c01f50682432adac18"
+		},
+		{
+			"ImportPath": "github.com/mailgun/oxy/trace",
+			"Rev": "519803a84411272a05b0b0c01f50682432adac18"
 		},
 		{
 			"ImportPath": "github.com/mailgun/oxy/utils",
-			"Rev": "3fc5acbe278c4dea6012dfc5101a00a59f79802d"
+			"Rev": "519803a84411272a05b0b0c01f50682432adac18"
 		},
 		{
 			"ImportPath": "github.com/mailgun/predicate",

--- a/Godeps/_workspace/src/github.com/mailgun/oxy/stream/stream.go
+++ b/Godeps/_workspace/src/github.com/mailgun/oxy/stream/stream.go
@@ -285,8 +285,6 @@ func (s *Streamer) copyRequest(req *http.Request, body io.ReadCloser, bodySize i
 	o.TransferEncoding = []string{}
 	// http.Transport will close the request body on any error, we are controlling the close process ourselves, so we override the closer here
 	o.Body = ioutil.NopCloser(body)
-	// Preserve TLS state if it's present
-	o.TLS = req.TLS
 	return &o
 }
 

--- a/Godeps/_workspace/src/github.com/mailgun/oxy/testutils/utils.go
+++ b/Godeps/_workspace/src/github.com/mailgun/oxy/testutils/utils.go
@@ -100,11 +100,10 @@ func MakeRequest(url string, opts ...ReqOption) (*http.Response, []byte, error) 
 		}
 	}
 
-	method := "GET"
 	if o.Method == "" {
 		o.Method = "GET"
 	}
-	request, _ := http.NewRequest(method, url, strings.NewReader(o.Body))
+	request, _ := http.NewRequest(o.Method, url, strings.NewReader(o.Body))
 	if o.Headers != nil {
 		utils.CopyHeaders(request.Header, o.Headers)
 	}

--- a/Godeps/_workspace/src/github.com/mailgun/oxy/trace/trace.go
+++ b/Godeps/_workspace/src/github.com/mailgun/oxy/trace/trace.go
@@ -35,7 +35,7 @@ func RequestHeaders(headers ...string) Option {
 // ResponseHeaders adds response headers to capture
 func ResponseHeaders(headers ...string) Option {
 	return func(t *Tracer) error {
-		t.respHeaders = append(t.reqHeaders, headers...)
+		t.respHeaders = append(t.respHeaders, headers...)
 		return nil
 	}
 }

--- a/Godeps/_workspace/src/github.com/mailgun/oxy/trace/trace.go
+++ b/Godeps/_workspace/src/github.com/mailgun/oxy/trace/trace.go
@@ -1,0 +1,212 @@
+// Package trace implement structured logging of requests
+package trace
+
+import (
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/mailgun/vulcand/Godeps/_workspace/src/github.com/mailgun/oxy/utils"
+)
+
+// Option is a functional option setter for Tracer
+type Option func(*Tracer) error
+
+// ErrorHandler is a functional argument that sets error handler of the server
+func ErrorHandler(h utils.ErrorHandler) Option {
+	return func(t *Tracer) error {
+		t.errHandler = h
+		return nil
+	}
+}
+
+// RequestHeaders adds request headers to capture
+func RequestHeaders(headers ...string) Option {
+	return func(t *Tracer) error {
+		t.reqHeaders = append(t.reqHeaders, headers...)
+		return nil
+	}
+}
+
+// ResponseHeaders adds response headers to capture
+func ResponseHeaders(headers ...string) Option {
+	return func(t *Tracer) error {
+		t.respHeaders = append(t.reqHeaders, headers...)
+		return nil
+	}
+}
+
+// Logger sets optional logger for trace used to report errors
+func Logger(l utils.Logger) Option {
+	return func(t *Tracer) error {
+		t.log = l
+		return nil
+	}
+}
+
+// Tracer records request and response emitting JSON structured data to the output
+type Tracer struct {
+	errHandler  utils.ErrorHandler
+	next        http.Handler
+	reqHeaders  []string
+	respHeaders []string
+	writer      io.Writer
+	log         utils.Logger
+}
+
+// New creates a new Tracer middleware that emits all the request/response information in structured format
+// to writer and passes the request to the next handler. It can optionally capture request and response headers,
+// see RequestHeaders and ResponseHeaders options for details.
+func New(next http.Handler, writer io.Writer, opts ...Option) (*Tracer, error) {
+	t := &Tracer{
+		writer: writer,
+		next:   next,
+	}
+	for _, o := range opts {
+		if err := o(t); err != nil {
+			return nil, err
+		}
+	}
+	if t.errHandler == nil {
+		t.errHandler = utils.DefaultHandler
+	}
+	if t.log == nil {
+		t.log = utils.NullLogger
+	}
+	return t, nil
+}
+
+func (t *Tracer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	start := time.Now()
+	pw := &utils.ProxyWriter{W: w}
+	t.next.ServeHTTP(pw, req)
+
+	l := t.newRecord(req, pw, time.Since(start))
+	if err := json.NewEncoder(t.writer).Encode(l); err != nil {
+		t.log.Errorf("Failed to marshal request: %v", err)
+	}
+}
+
+func (t *Tracer) newRecord(req *http.Request, pw *utils.ProxyWriter, diff time.Duration) *Record {
+	r := &Record{
+		Request: Request{
+			Method:  req.Method,
+			URL:     req.URL.String(),
+			TLS:     newTLS(req),
+			Headers: captureHeaders(req.Header, t.reqHeaders),
+		},
+		Response: Response{
+			Code:      pw.StatusCode(),
+			Roundtrip: float64(diff) / float64(time.Millisecond),
+			Headers:   captureHeaders(pw.Header(), t.respHeaders),
+		},
+	}
+	return r
+}
+
+func newTLS(req *http.Request) *TLS {
+	if req.TLS == nil {
+		return nil
+	}
+	return &TLS{
+		Version:     versionToString(req.TLS.Version),
+		Resume:      req.TLS.DidResume,
+		CipherSuite: csToString(req.TLS.CipherSuite),
+		Server:      req.TLS.ServerName,
+	}
+}
+
+func captureHeaders(in http.Header, headers []string) http.Header {
+	if len(headers) == 0 || in == nil {
+		return nil
+	}
+	out := make(http.Header, len(headers))
+	for _, h := range headers {
+		vals, ok := in[h]
+		if !ok || len(out[h]) != 0 {
+			continue
+		}
+		for i := range vals {
+			out.Add(h, vals[i])
+		}
+	}
+	return out
+}
+
+// Record represents a structured request and response record
+type Record struct {
+	Request  Request  `json:"request"`
+	Response Response `json:"response"`
+}
+
+// Req contains information about an HTTP request
+type Request struct {
+	Method  string      `json:"method"`            // Method - request method
+	URL     string      `json:"url"`               // URL - Request URL
+	Headers http.Header `json:"headers,omitempty"` // Headers - optional request headers, will be recorded if configured
+	TLS     *TLS        `json:"tls,omitempty"`     // TLS - optional TLS record, will be recorded if it's a TLS connection
+}
+
+// Resp contains information about HTTP response
+type Response struct {
+	Code      int         `json:"code"`              // Code - response status code
+	Roundtrip float64     `json:"roundtrip"`         // Roundtrip - round trip time in milliseconds
+	Headers   http.Header `json:"headers,omitempty"` // Headers - optional headers, will be recorded if configured
+}
+
+// TLS contains information about this TLS connection
+type TLS struct {
+	Version     string `json:"version"`      // Version - TLS version
+	Resume      bool   `json:"resume"`       // Resume tells if the session has been re-used (session tickets)
+	CipherSuite string `json:"cipher_suite"` // CipherSuite contains cipher suite used for this connection
+	Server      string `json:"server"`       // Server contains server name used in SNI
+}
+
+func versionToString(v uint16) string {
+	switch v {
+	case tls.VersionSSL30:
+		return "SSL30"
+	case tls.VersionTLS10:
+		return "TLS10"
+	case tls.VersionTLS11:
+		return "TLS11"
+	case tls.VersionTLS12:
+		return "TLS12"
+	}
+	return fmt.Sprintf("unknown: %x", v)
+}
+
+func csToString(cs uint16) string {
+	switch cs {
+	case tls.TLS_RSA_WITH_RC4_128_SHA:
+		return "TLS_RSA_WITH_RC4_128_SHA"
+	case tls.TLS_RSA_WITH_3DES_EDE_CBC_SHA:
+		return "TLS_RSA_WITH_3DES_EDE_CBC_SHA"
+	case tls.TLS_RSA_WITH_AES_128_CBC_SHA:
+		return "TLS_RSA_WITH_AES_128_CBC_SHA"
+	case tls.TLS_RSA_WITH_AES_256_CBC_SHA:
+		return "TLS_RSA_WITH_AES_256_CBC_SHA"
+	case tls.TLS_ECDHE_ECDSA_WITH_RC4_128_SHA:
+		return "TLS_ECDHE_ECDSA_WITH_RC4_128_SHA"
+	case tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA:
+		return "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA"
+	case tls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA:
+		return "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA"
+	case tls.TLS_ECDHE_RSA_WITH_RC4_128_SHA:
+		return "TLS_ECDHE_RSA_WITH_RC4_128_SHA"
+	case tls.TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA:
+		return "TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA"
+	case tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA:
+		return "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA"
+	case tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA:
+		return "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA"
+	case tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256:
+		return "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
+	case tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256:
+		return "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256"
+	}
+	return fmt.Sprintf("unknown: %x", cs)
+}

--- a/Godeps/_workspace/src/github.com/mailgun/oxy/trace/trace_test.go
+++ b/Godeps/_workspace/src/github.com/mailgun/oxy/trace/trace_test.go
@@ -1,0 +1,122 @@
+package trace
+
+import (
+	"bufio"
+	"bytes"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/mailgun/vulcand/Godeps/_workspace/src/github.com/mailgun/oxy/testutils"
+	"github.com/mailgun/vulcand/Godeps/_workspace/src/github.com/mailgun/oxy/utils"
+	. "github.com/mailgun/vulcand/Godeps/_workspace/src/gopkg.in/check.v1"
+)
+
+func TestTrace(t *testing.T) { TestingT(t) }
+
+type TraceSuite struct{}
+
+var _ = Suite(&TraceSuite{})
+
+func (s *TraceSuite) TestTraceSimple(c *C) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		w.Write([]byte("hello"))
+	})
+	buf := &bytes.Buffer{}
+	l := utils.NewFileLogger(buf, utils.INFO)
+
+	trace := &bytes.Buffer{}
+
+	t, err := New(handler, trace, Logger(l))
+	c.Assert(err, IsNil)
+
+	srv := httptest.NewServer(t)
+	defer srv.Close()
+
+	re, _, err := testutils.Get(srv.URL + "/hello")
+	c.Assert(err, IsNil)
+	c.Assert(re.StatusCode, Equals, http.StatusOK)
+
+	var r *Record
+	c.Assert(json.Unmarshal(trace.Bytes(), &r), IsNil)
+
+	c.Assert(r.Request.Method, Equals, "GET")
+	c.Assert(r.Request.URL, Equals, "/hello")
+	c.Assert(r.Response.Code, Equals, http.StatusOK)
+	c.Assert(r.Response.Roundtrip, Not(Equals), float64(0))
+}
+
+func (s *TraceSuite) TestTraceCaptureHeaders(c *C) {
+	respHeaders := http.Header{
+		"X-Re-1": []string{"6", "7"},
+		"X-Re-2": []string{"2", "3"},
+	}
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		utils.CopyHeaders(w.Header(), respHeaders)
+		w.Write([]byte("hello"))
+	})
+	buf := &bytes.Buffer{}
+	l := utils.NewFileLogger(buf, utils.INFO)
+
+	trace := &bytes.Buffer{}
+
+	t, err := New(handler, trace, Logger(l), RequestHeaders("X-Req-B", "X-Req-A"), ResponseHeaders("X-Re-1", "X-Re-2"))
+	c.Assert(err, IsNil)
+
+	srv := httptest.NewServer(t)
+	defer srv.Close()
+
+	reqHeaders := http.Header{"X-Req-A": []string{"1", "2"}, "X-Req-B": []string{"3", "4"}}
+	re, _, err := testutils.Get(srv.URL+"/hello", testutils.Headers(reqHeaders))
+	c.Assert(err, IsNil)
+	c.Assert(re.StatusCode, Equals, http.StatusOK)
+
+	var r *Record
+	c.Assert(json.Unmarshal(trace.Bytes(), &r), IsNil)
+
+	c.Assert(r.Request.Headers, DeepEquals, reqHeaders)
+	c.Assert(r.Response.Headers, DeepEquals, respHeaders)
+}
+
+func (s *TraceSuite) TestTraceTLS(c *C) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		w.Write([]byte("hello"))
+	})
+	buf := &bytes.Buffer{}
+	l := utils.NewFileLogger(buf, utils.INFO)
+
+	trace := &bytes.Buffer{}
+
+	t, err := New(handler, trace, Logger(l))
+	c.Assert(err, IsNil)
+
+	srv := httptest.NewUnstartedServer(t)
+	srv.StartTLS()
+	defer srv.Close()
+
+	config := &tls.Config{
+		InsecureSkipVerify: true,
+	}
+
+	u, err := url.Parse(srv.URL)
+	c.Assert(err, IsNil)
+
+	conn, err := tls.Dial("tcp", u.Host, config)
+	c.Assert(err, IsNil)
+
+	fmt.Fprintf(conn, "GET / HTTP/1.0\r\n\r\n")
+	status, err := bufio.NewReader(conn).ReadString('\n')
+	c.Assert(status, Equals, "HTTP/1.0 200 OK\r\n")
+	state := conn.ConnectionState()
+	conn.Close()
+
+	var r *Record
+	fmt.Printf("%v", string(trace.Bytes()))
+	c.Assert(json.Unmarshal(trace.Bytes(), &r), IsNil)
+	c.Assert(r.Request.TLS.Version, Equals, versionToString(state.Version))
+}

--- a/Godeps/_workspace/src/github.com/mailgun/oxy/utils/netutils.go
+++ b/Godeps/_workspace/src/github.com/mailgun/oxy/utils/netutils.go
@@ -6,9 +6,21 @@ import (
 	"net/url"
 )
 
+// ProxyWriter helps to capture response headers and status code
+// from the ServeHTTP. It can be safely passed to ServeHTTP handler,
+// wrapping the real response writer.
 type ProxyWriter struct {
 	W    http.ResponseWriter
 	Code int
+}
+
+func (p *ProxyWriter) StatusCode() int {
+	if p.Code == 0 {
+		// per contract standard lib will set this to http.StatusOK if not set
+		// by user, here we avoid the confusion by mirroring this logic
+		return http.StatusOK
+	}
+	return p.Code
 }
 
 func (p *ProxyWriter) Header() http.Header {

--- a/plugin/registry/registry.go
+++ b/plugin/registry/registry.go
@@ -7,6 +7,7 @@ import (
 	"github.com/mailgun/vulcand/plugin/connlimit"
 	"github.com/mailgun/vulcand/plugin/ratelimit"
 	"github.com/mailgun/vulcand/plugin/rewrite"
+	"github.com/mailgun/vulcand/plugin/trace"
 )
 
 func GetRegistry() *plugin.Registry {
@@ -25,6 +26,10 @@ func GetRegistry() *plugin.Registry {
 	}
 
 	if err := r.AddSpec(cbreaker.GetSpec()); err != nil {
+		panic(err)
+	}
+
+	if err := r.AddSpec(trace.GetSpec()); err != nil {
 		panic(err)
 	}
 

--- a/plugin/registry/registry.go
+++ b/plugin/registry/registry.go
@@ -13,24 +13,18 @@ import (
 func GetRegistry() *plugin.Registry {
 	r := plugin.NewRegistry()
 
-	if err := r.AddSpec(ratelimit.GetSpec()); err != nil {
-		panic(err)
+	specs := []*plugin.MiddlewareSpec{
+		ratelimit.GetSpec(),
+		connlimit.GetSpec(),
+		rewrite.GetSpec(),
+		cbreaker.GetSpec(),
+		trace.GetSpec(),
 	}
 
-	if err := r.AddSpec(connlimit.GetSpec()); err != nil {
-		panic(err)
-	}
-
-	if err := r.AddSpec(rewrite.GetSpec()); err != nil {
-		panic(err)
-	}
-
-	if err := r.AddSpec(cbreaker.GetSpec()); err != nil {
-		panic(err)
-	}
-
-	if err := r.AddSpec(trace.GetSpec()); err != nil {
-		panic(err)
+	for _, spec := range specs {
+		if err := r.AddSpec(spec); err != nil {
+			panic(err)
+		}
 	}
 
 	return r

--- a/plugin/rewrite/rewrite_test.go
+++ b/plugin/rewrite/rewrite_test.go
@@ -1,11 +1,6 @@
 package rewrite
 
 import (
-	/*	"io"
-		"io/ioutil"
-
-		"strings"
-	*/
 	"net/http"
 	"net/http/httptest"
 	"regexp"

--- a/plugin/trace/trace.go
+++ b/plugin/trace/trace.go
@@ -1,0 +1,205 @@
+package trace
+
+import (
+	"fmt"
+	"io"
+	"log/syslog"
+	"net/http"
+	"net/url"
+
+	"github.com/mailgun/vulcand/Godeps/_workspace/src/github.com/codegangsta/cli"
+	oxytrace "github.com/mailgun/vulcand/Godeps/_workspace/src/github.com/mailgun/oxy/trace"
+	"github.com/mailgun/vulcand/plugin"
+)
+
+const Type = "trace"
+
+// Trace plugin emits structured logs to syslog facility
+type Trace struct {
+	// ReqHeaders - request headers to capture
+	ReqHeaders []string
+	// RespHeaders - response headers to capture
+	RespHeaders []string
+	// Address in format syslog://host:port or syslog:///path/socket.sock
+	Addr string
+}
+
+// New returns a new Trace plugin
+func New(addr string, reqHeaders, respHeaders []string) (*Trace, error) {
+	if _, err := newWriter(addr); err != nil {
+		return nil, err
+	}
+	return &Trace{
+		ReqHeaders:  reqHeaders,
+		RespHeaders: respHeaders,
+		Addr:        addr,
+	}, nil
+}
+
+// NewHandler creates a new http.Handler middleware
+func (t *Trace) NewHandler(next http.Handler) (http.Handler, error) {
+	return newTraceHandler(next, t)
+}
+
+// String is a user-friendly representation of the handler
+func (t *Trace) String() string {
+	return fmt.Sprintf("addr=%v, reqHeaders=%v, respHeaders=%v", t.Addr, t.ReqHeaders, t.RespHeaders)
+}
+
+func newTraceHandler(next http.Handler, t *Trace) (*oxytrace.Tracer, error) {
+	writer, err := newWriter(t.Addr)
+	if err != nil {
+		return nil, err
+	}
+	return oxytrace.New(next, writer, oxytrace.RequestHeaders(t.ReqHeaders...), oxytrace.ResponseHeaders(t.RespHeaders...))
+}
+
+// FromOther creates and validates Trace plugin instance from serialized format
+func FromOther(t Trace) (plugin.Middleware, error) {
+	return New(t.Addr, t.ReqHeaders, t.RespHeaders)
+}
+
+// FromCli creates a Trace plugin object from command line
+func FromCli(c *cli.Context) (plugin.Middleware, error) {
+	return New(c.String("addr"), c.StringSlice("reqHeader"), c.StringSlice("respHeader"))
+}
+
+// GetSpec returns all information neccessary for Vulcand to plugin this extension
+func GetSpec() *plugin.MiddlewareSpec {
+	return &plugin.MiddlewareSpec{
+		Type:      Type,
+		FromOther: FromOther,
+		FromCli:   FromCli,
+		CliFlags:  CliFlags(),
+	}
+}
+
+// CliFlags is used to add command-line arguments to the CLI tool - vctl
+func CliFlags() []cli.Flag {
+	return []cli.Flag{
+		cli.StringFlag{
+			Name:  "addr",
+			Usage: "Address of the output, e.g. syslog:///tmp/out.sock",
+		},
+		cli.StringSliceFlag{
+			Name:  "reqHeader",
+			Usage: "if provided, captures headers from requests",
+			Value: &cli.StringSlice{},
+		},
+		cli.StringSliceFlag{
+			Name:  "respHeader",
+			Usage: "if provided, captures headers from response",
+			Value: &cli.StringSlice{},
+		},
+	}
+}
+
+func newWriter(addr string) (io.Writer, error) {
+	u, err := url.Parse(addr)
+	if u.Scheme != "syslog" {
+		return nil, fmt.Errorf("unsupported scheme '%v' currently supported only 'syslog'", u.Scheme)
+	}
+	pr, err := parseSyslogPriority(u)
+	if err != nil {
+		return nil, err
+	}
+	if u.Host != "" {
+		return syslog.Dial("udp", u.Host, pr, parsePrefix(u))
+	} else if u.Path != "" {
+		return syslog.Dial("unixgram", u.Path, pr, parsePrefix(u))
+	} else if u.Host == "" && u.Path == "" {
+		return syslog.Dial("", "", pr, parsePrefix(u))
+	}
+	return nil, fmt.Errorf("unsupported address format: %v", addr)
+}
+
+func parsePrefix(u *url.URL) string {
+	t := u.Query().Get("prefix")
+	if t != "" {
+		return t
+	}
+	return SyslogPrefix
+}
+
+func parseSyslogPriority(u *url.URL) (syslog.Priority, error) {
+	vals := u.Query()
+	pr, err := sevToString(vals.Get("sev"))
+	if err != nil {
+		return 0, err
+	}
+	f, err := fToString(vals.Get("f"))
+	if err != nil {
+		return 0, err
+	}
+	return pr | f, nil
+}
+
+func sevToString(sev string) (pr syslog.Priority, err error) {
+	switch sev {
+	case "ALERT":
+		pr |= syslog.LOG_ALERT
+	case "CRIT":
+		pr |= syslog.LOG_CRIT
+	case "ERR":
+		pr |= syslog.LOG_ERR
+	case "WARNING":
+		pr |= syslog.LOG_WARNING
+	case "NOTICE":
+		pr |= syslog.LOG_NOTICE
+	case "INFO":
+		pr |= syslog.LOG_INFO
+	case "DEBUG", "":
+		pr |= syslog.LOG_DEBUG
+	default:
+		return pr, fmt.Errorf("uknown severity: %v", sev)
+	}
+	return pr, nil
+}
+
+func fToString(v string) (f syslog.Priority, err error) {
+	switch v {
+	case "USER":
+		f |= syslog.LOG_USER
+	case "MAIL":
+		f |= syslog.LOG_MAIL
+	case "DAEMON":
+		f |= syslog.LOG_DAEMON
+	case "AUTH":
+		f |= syslog.LOG_AUTH
+	case "SYSLOG":
+		f |= syslog.LOG_SYSLOG
+	case "LPR":
+		f |= syslog.LOG_LPR
+	case "NEWS":
+		f |= syslog.LOG_NEWS
+	case "UUCP":
+		f |= syslog.LOG_UUCP
+	case "CRON":
+		f |= syslog.LOG_CRON
+	case "AUTHPRIV":
+		f |= syslog.LOG_AUTHPRIV
+	case "FTP":
+		f |= syslog.LOG_FTP
+	case "LOG_LOCAL0", "":
+		f |= syslog.LOG_LOCAL0
+	case "LOG_LOCAL1":
+		f |= syslog.LOG_LOCAL1
+	case "LOG_LOCAL2":
+		f |= syslog.LOG_LOCAL2
+	case "LOG_LOCAL3":
+		f |= syslog.LOG_LOCAL3
+	case "LOG_LOCAL4":
+		f |= syslog.LOG_LOCAL4
+	case "LOG_LOCAL5":
+		f |= syslog.LOG_LOCAL5
+	case "LOG_LOCAL6":
+		f |= syslog.LOG_LOCAL6
+	case "LOG_LOCAL7":
+		f |= syslog.LOG_LOCAL7
+	default:
+		return 0, fmt.Errorf("unsupported facility: %v", v)
+	}
+	return f, nil
+}
+
+const SyslogPrefix = "@json:"

--- a/plugin/trace/trace.go
+++ b/plugin/trace/trace.go
@@ -151,7 +151,7 @@ func sevToString(sev string) (pr syslog.Priority, err error) {
 	case "DEBUG", "":
 		pr |= syslog.LOG_DEBUG
 	default:
-		return pr, fmt.Errorf("uknown severity: %v", sev)
+		return 0, fmt.Errorf("uknown severity: %v", sev)
 	}
 	return pr, nil
 }

--- a/plugin/trace/trace_test.go
+++ b/plugin/trace/trace_test.go
@@ -68,7 +68,7 @@ func (s *TraceSuite) TestBadAddr(c *C) {
 }
 
 func (s *TraceSuite) TestHandler(c *C) {
-	c.Assert(os.Remove("/tmp/vulcand_trace_test.sock"), IsNil)
+	os.Remove("/tmp/vulcand_trace_test.sock")
 	unixAddr, err := net.ResolveUnixAddr("unixgram", "/tmp/vulcand_trace_test.sock")
 	c.Assert(err, IsNil)
 	conn, err := net.ListenUnixgram("unixgram", unixAddr)

--- a/plugin/trace/trace_test.go
+++ b/plugin/trace/trace_test.go
@@ -1,0 +1,150 @@
+package trace
+
+import (
+	"encoding/json"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/mailgun/vulcand/Godeps/_workspace/src/github.com/codegangsta/cli"
+	"github.com/mailgun/vulcand/Godeps/_workspace/src/github.com/mailgun/oxy/testutils"
+	oxytrace "github.com/mailgun/vulcand/Godeps/_workspace/src/github.com/mailgun/oxy/trace"
+	. "github.com/mailgun/vulcand/Godeps/_workspace/src/gopkg.in/check.v1"
+	"github.com/mailgun/vulcand/plugin"
+)
+
+func TestTrace(t *testing.T) { TestingT(t) }
+
+type TraceSuite struct {
+}
+
+var _ = Suite(&TraceSuite{})
+
+// One of the most important tests:
+// Make sure the Rewrite spec is compatible and will be accepted by middleware registry
+func (s *TraceSuite) TestSpecIsOK(c *C) {
+	c.Assert(plugin.NewRegistry().AddSpec(GetSpec()), IsNil)
+}
+
+func (s *TraceSuite) TestGoodAddr(c *C) {
+	vals := []string{
+		// host + port format
+		"syslog://localhost:5000",
+		"syslog://localhost:5000?f=MAIL&sev=INFO",
+		"syslog://localhost:5000?f=MAIL",
+		"syslog://localhost:5000?f=LOG_LOCAL0&sev=DEBUG",
+
+		// local socket format
+		"syslog:///dev/log",
+		"syslog:///dev/log?f=MAIL",
+		"syslog:///dev/log?f=LOG_LOCAL0",
+
+		// default syslog
+		"syslog://",
+		"syslog://?f=LOG_LOCAL0&sev=INFO",
+	}
+	for _, v := range vals {
+		out, err := newWriter(v)
+		c.Assert(err, IsNil)
+		c.Assert(out, NotNil)
+	}
+}
+
+func (s *TraceSuite) TestBadAddr(c *C) {
+	vals := []string{
+		"omglog://",
+		"syslog://localhost:5000?f=SHMAIL",
+		"syslog://localhost:5000?sev=SHMEVERITY",
+	}
+	for _, v := range vals {
+		out, err := newWriter(v)
+		c.Assert(err, NotNil)
+		c.Assert(out, IsNil)
+	}
+}
+
+func (s *TraceSuite) TestHandler(c *C) {
+	c.Assert(os.Remove("/tmp/vulcand_trace_test.sock"), IsNil)
+	unixAddr, err := net.ResolveUnixAddr("unixgram", "/tmp/vulcand_trace_test.sock")
+	c.Assert(err, IsNil)
+	conn, err := net.ListenUnixgram("unixgram", unixAddr)
+	c.Assert(err, IsNil)
+	defer conn.Close()
+
+	outC := make(chan []byte, 1000)
+	closeC := make(chan bool)
+	defer close(closeC)
+	go func() {
+		for {
+			buf := make([]byte, 65536)
+			bytes, err := conn.Read(buf)
+			if err != nil {
+				return
+			}
+			outbuf := make([]byte, bytes)
+			copy(outbuf, buf)
+			select {
+			case <-closeC:
+				return
+			case outC <- outbuf:
+				continue
+			}
+		}
+	}()
+
+	responder := http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		w.Header().Add("X-Resp-A", "h2")
+		w.Write([]byte("hello"))
+	})
+
+	h, err := New("syslog:///tmp/vulcand_trace_test.sock?tag=@json:", []string{"X-Req-A"}, []string{"X-Resp-A"})
+	c.Assert(err, IsNil)
+
+	handler, err := h.NewHandler(responder)
+	c.Assert(err, IsNil)
+
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	re, _, err := testutils.Get(srv.URL+"/hello", testutils.Header("X-Req-A", "yo"))
+	c.Assert(err, IsNil)
+	c.Assert(re.StatusCode, Equals, http.StatusOK)
+
+	var buf []byte
+	select {
+	case buf = <-outC:
+	case <-time.After(10 * time.Millisecond):
+		c.Fatalf("timeout")
+	}
+
+	vals := strings.Split(string(buf), "]: ")
+	var r *oxytrace.Record
+	c.Assert(json.Unmarshal([]byte(vals[1]), &r), IsNil)
+	c.Assert(r.Request.URL, Equals, "/hello")
+	c.Assert(r.Request.Headers, DeepEquals, http.Header{"X-Req-A": []string{"yo"}})
+	c.Assert(r.Response.Headers, DeepEquals, http.Header{"X-Resp-A": []string{"h2"}})
+}
+
+func (s *TraceSuite) TestNewFromCLI(c *C) {
+	app := cli.NewApp()
+	app.Name = "test"
+	executed := false
+	app.Action = func(ctx *cli.Context) {
+		executed = true
+		out, err := FromCli(ctx)
+		c.Assert(out, NotNil)
+		c.Assert(err, IsNil)
+
+		t := out.(*Trace)
+		c.Assert(t.Addr, Equals, "syslog:///dev/log?sev=INFO&f=MAIL")
+		c.Assert(t.ReqHeaders, DeepEquals, []string{"X-A", "X-B"})
+		c.Assert(t.RespHeaders, DeepEquals, []string{"X-C", "X-D"})
+	}
+	app.Flags = CliFlags()
+	app.Run([]string{"test", "--addr=syslog:///dev/log?sev=INFO&f=MAIL", "--reqHeader=X-A", "--reqHeader=X-B", "--respHeader=X-C", "--respHeader=X-D"})
+	c.Assert(executed, Equals, true)
+}

--- a/vbundle/main.go
+++ b/vbundle/main.go
@@ -112,6 +112,7 @@ func builtinPackages() []Package {
 		"github.com/mailgun/vulcand/plugin/ratelimit",
 		"github.com/mailgun/vulcand/plugin/rewrite",
 		"github.com/mailgun/vulcand/plugin/cbreaker",
+		"github.com/mailgun/vulcand/plugin/trace",
 	}
 }
 

--- a/vbundle/templates.go
+++ b/vbundle/templates.go
@@ -36,11 +36,17 @@ import (
 func GetRegistry() (*plugin.Registry, error) {
 	r := plugin.NewRegistry()
 
-	{{range .Packages}}
-	if err := r.AddSpec({{.Name}}.GetSpec()); err != nil {
-		return nil, err
+	specs := []*plugin.MiddlewareSpec{
+		{{range .Packages}}
+		{{.Name}}.GetSpec(),
+       {{end}}
 	}
-	{{end}}
+
+	for _, spec := range specs {
+		if err := r.AddSpec(spec); err != nil {
+			return nil, err
+		}
+	}
 	return r, nil
 }
 `


### PR DESCRIPTION
Purpose
-----------

We need to be able to capture HTTPS access logs in structured format for debugging purposes.

Implementation
--------------------
Trace plugin outputs information about requests in structured format to any unix or udp socket. It uses syslog format to emit logs. The syslog prefix can be removed and JSON part can be put into ELK cluster.