### PR TITLE
Emit gaguges once a second instead of emitting individual entries

### DIFF
--- a/proxy/frontend.go
+++ b/proxy/frontend.go
@@ -117,9 +117,8 @@ func (f *frontend) rebuild() error {
 				TrustForwardHeader: settings.TrustForwardHeader,
 			}))
 
-	// reporter and rtwatcher will be observing metrics
-	rp := NewReporter(fwd, f.mux.options.MetricsClient, engine.FrontendKey{Id: f.frontend.Id})
-	watcher, err := NewWatcher(rp)
+	// rtwatcher will be observing and aggregating metrics
+	watcher, err := NewWatcher(fwd)
 	if err != nil {
 		return err
 	}

--- a/proxy/mux_test.go
+++ b/proxy/mux_test.go
@@ -1028,6 +1028,9 @@ func (s *ServerSuite) TestGetStats(c *C) {
 	topServers, err := s.mux.TopServers(nil)
 	c.Assert(err, IsNil)
 	c.Assert(len(topServers), Equals, 2)
+
+	// emit stats works without errors
+	c.Assert(s.mux.emitMetrics(), IsNil)
 }
 
 func GETResponse(c *C, url string, opts ...testutils.ReqOption) string {


### PR DESCRIPTION
Purpose
----------
Statsd becomes a bottleneck for highly concurrent and frequent requests, as it results in syscall and locking on every request

Implementation
-------------------
Emit gauges instead of individual metrics to statsd every second, speeds up the process significantly.