### PR TITLE
Update .travis.yml, remove sudo option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,3 @@ go:
         - 1.4
 script:
         - go test -v ./...
-
-sudo: false


### PR DESCRIPTION
Fixes `TestTrace` error '/dev/log: no such file or directory'