### PR TITLE
Build vulcand in a scratch container

### DIFF
--- a/Dockerfile-scratch
+++ b/Dockerfile-scratch
@@ -1,0 +1,9 @@
+FROM scratch
+EXPOSE 8181 8182
+COPY vulcand /app/vulcand
+COPY ./vctl/vctl /app/vctl
+COPY ./vbundle/vbundle /app/vbundle
+ENV PATH=/app:$PATH
+
+ENTRYPOINT ["/app/vulcand"]
+CMD ["-etcd=http://127.0.0.1:4001", "-etcd=127.0.0.1:4002", "-etcd=127.0.0.1:4003", "-sealKey=1b727a055500edd9ab826840ce9428dc8bace1c04addc67bbac6b096e25ede4b"]

--- a/Makefile
+++ b/Makefile
@@ -72,3 +72,18 @@ run-test-mode: install
 
 profile:
 	go tool pprof http://localhost:6060/debug/pprof/profile
+
+docker-clean:
+	docker rm -f vulcand
+
+docker-build:
+	go build -a -tags netgo -installsuffix cgo -ldflags '-w' -o ./vulcand .
+	go build -a -tags netgo -installsuffix cgo -ldflags '-w' -o ./vctl/vctl ./vctl
+	go build -a -tags netgo -installsuffix cgo -ldflags '-w' -o ./vbundle/vbundle ./vbundle
+	docker build -t mailgun/vulcand:latest -f ./Dockerfile-scratch .
+
+docker-run-fast: docker-build
+	docker run -d --net=host --name vulcand mailgun/vulcand -etcd=${ETCD_NODE1} -etcd=${ETCD_NODE2} -etcd=${ETCD_NODE3} -etcdKey=/vulcand -sealKey=${SEAL_KEY}
+
+docker-run-test-mode: docker-build
+	docker run -d --net=host --name vulcand mailgun/vulcand -etcd=${ETCD_NODE1} -etcd=${ETCD_NODE2} -etcd=${ETCD_NODE3} -etcdKey=${PREFIX} -sealKey=${SEAL_KEY} -logSeverity=INFO


### PR DESCRIPTION
Vulcand, built in a scratch container for Go 1.4

The container is 18.86MB.