### PR TITLE
Add ability to build minimal docker image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,6 +82,9 @@ docker-build:
 	go build -a -tags netgo -installsuffix cgo -ldflags '-w' -o ./vbundle/vbundle ./vbundle
 	docker build -t mailgun/vulcand:latest -f ./Dockerfile-scratch .
 
+docker-minimal-linux:
+	bash scripts/build-minimal-linux.sh ${SEAL_KEY}
+
 docker-run-fast: docker-build
 	docker run -d --net=host --name vulcand mailgun/vulcand -etcd=${ETCD_NODE1} -etcd=${ETCD_NODE2} -etcd=${ETCD_NODE3} -etcdKey=/vulcand -sealKey=${SEAL_KEY}
 

--- a/scripts/build-minimal-linux.sh
+++ b/scripts/build-minimal-linux.sh
@@ -1,0 +1,8 @@
+docker run --rm \
+ -v /var/run/docker.sock:/var/run/docker.sock \
+ -v $(which docker):$(which docker) \
+ -v $(pwd):$(pwd) \
+ -e HOST_PROJECT_PATH=$(pwd) \
+ -e HOST_GOPATH=${GOPATH} \
+ -e DOCKER_IMAGE_NAME=${DOCKER_IMAGE_NAME-mailgun/vulcand} \
+ golang:1.4-onbuild bash $(pwd)/scripts/static-compile-docker.sh

--- a/scripts/static-compile-docker.sh
+++ b/scripts/static-compile-docker.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# This script is designed to be run from ../Makefile via `make docker-minimal-linux`.
+# $1 - Seal key to build with
+#
+# Overridable variables:
+# GO_PROJECT_PATH: go import path for the project
+# DOCKER_IMAGE_NAME: name for final docker image
+# DOCKER_IMAGE_TAG: tag for final docker image
+
+GO_PROJECT_PATH=${GO_PROJECT_PATH-github.com/mailgun/vulcand}
+
+echo "Building go project \"$GO_PROJECT_PATH\""
+
+cp -a ${HOST_PROJECT_PATH} ${GOPATH}/src/
+go get vulcand
+go get vulcand/vctl
+go get vulcand/vbundle
+
+# Fixes for statically compling on go1.4 - https://github.com/golang/go/issues/9344
+CGO_ENABLED=0 go build -a -tags netgo -installsuffix cgo --ldflags '-extldflags \"-static\" -s -w' ${GO_PROJECT_PATH}
+CGO_ENABLED=0 go build -a -tags netgo -installsuffix cgo --ldflags '-extldflags \"-static\" -s -w' ${GO_PROJECT_PATH}/vctl
+CGO_ENABLED=0 go build -a -tags netgo -installsuffix cgo --ldflags '-extldflags \"-static\" -s -w' ${GO_PROJECT_PATH}/vbundle
+
+cat > Dockerfile-minimal << EOF
+FROM scratch
+EXPOSE 8181 8182
+COPY vulcand /app/vulcand
+COPY vctl /app/vctl
+COPY vbundle /app/vbundle
+ENV PATH=/app:$PATH
+
+ENTRYPOINT ["/app/vulcand"]
+CMD ["-etcd=http://127.0.0.1:4001", "-etcd=127.0.0.1:4002", "-etcd=127.0.0.1:4003", "-sealKey=$1"]
+EOF
+
+docker build --no-cache -t ${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG-latest} -f Dockerfile-minimal .


### PR DESCRIPTION
This adds the ability to build a statically linked,
minimal docker image via the existing Makefile. The
is done via Docker using the golang1.4-onbuild image.

The resulting image is ~18MB. I have one pushed at 
`quay.io/doublerr/vulcand`.

I'm still learning the go build process so I'm sure there
is plenty of room for improvement. Feedback welcome!

Ryan