### PR TITLE
Declare phony targets in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,3 +90,5 @@ docker-run-fast: docker-build
 
 docker-run-test-mode: docker-build
 	docker run -d --net=host --name vulcand mailgun/vulcand -etcd=${ETCD_NODE1} -etcd=${ETCD_NODE2} -etcd=${ETCD_NODE3} -etcdKey=${PREFIX} -sealKey=${SEAL_KEY} -logSeverity=INFO
+
+.PHONY: test test-with-etcd test-with-vulcan clean test-package test-package-with-etcd update test-grep-etcdng test-grep-package cover-package cover-package-with-etcd systest systest-grep sloccount install run run-fast run-test-mode profile docker-clean docker-build docker-minimal-linux docker-run-fast docker-run-test-mode


### PR DESCRIPTION
All the targets in makefile seems to be phony targets. So, I added a ```.PHONY``` section.