### PR TITLE
Allow adding a custom NotFound middleware to Vulcan.

### DIFF
--- a/plugin/middleware.go
+++ b/plugin/middleware.go
@@ -53,14 +53,13 @@ type SpecGetter func(string) *MiddlewareSpec
 
 // Registry contains currently registered middlewares and used to support pluggable middlewares across all modules of the vulcand
 type Registry struct {
-	specs              []*MiddlewareSpec
-	notFoundMiddleware Middleware
+	specs    []*MiddlewareSpec
+	notFound Middleware
 }
 
 func NewRegistry() *Registry {
 	return &Registry{
-		specs:              []*MiddlewareSpec{},
-		notFoundMiddleware: nil,
+		specs: []*MiddlewareSpec{},
 	}
 }
 
@@ -91,13 +90,13 @@ func (r *Registry) GetSpecs() []*MiddlewareSpec {
 	return r.specs
 }
 
-func (r *Registry) AddNotFoundMiddleware(notFoundMiddleware Middleware) error {
-	r.notFoundMiddleware = notFoundMiddleware
+func (r *Registry) AddNotFoundMiddleware(notFound Middleware) error {
+	r.notFound = notFound
 	return nil
 }
 
 func (r *Registry) GetNotFoundMiddleware() Middleware {
-	return r.notFoundMiddleware
+	return r.notFound
 }
 
 func verifySignature(fn interface{}) error {

--- a/plugin/middleware.go
+++ b/plugin/middleware.go
@@ -53,12 +53,14 @@ type SpecGetter func(string) *MiddlewareSpec
 
 // Registry contains currently registered middlewares and used to support pluggable middlewares across all modules of the vulcand
 type Registry struct {
-	specs []*MiddlewareSpec
+	specs              []*MiddlewareSpec
+	notFoundMiddleware Middleware
 }
 
 func NewRegistry() *Registry {
 	return &Registry{
-		specs: []*MiddlewareSpec{},
+		specs:              []*MiddlewareSpec{},
+		notFoundMiddleware: nil,
 	}
 }
 
@@ -87,6 +89,15 @@ func (r *Registry) GetSpec(middlewareType string) *MiddlewareSpec {
 
 func (r *Registry) GetSpecs() []*MiddlewareSpec {
 	return r.specs
+}
+
+func (r *Registry) AddNotFoundMiddleware(notFoundMiddleware Middleware) error {
+	r.notFoundMiddleware = notFoundMiddleware
+	return nil
+}
+
+func (r *Registry) GetNotFoundMiddleware() Middleware {
+	return r.notFoundMiddleware
 }
 
 func verifySignature(fn interface{}) error {

--- a/plugin/middleware_test.go
+++ b/plugin/middleware_test.go
@@ -97,12 +97,23 @@ func (s *MiddlewareSuite) TestRegistryAddSpecBadSignature(c *C) {
 	c.Assert(r.AddSpec(&MiddlewareSpec{}), NotNil)
 }
 
-type TestMiddleware struct {
-	Field string
+func (s *MiddlewareSuite) TestRegistryNotFoundMiddlewareGetSet(c *C) {
+	r := NewRegistry()
+	correct := &TestMiddleware{Field: "notfound"}
+	r.AddNotFoundMiddleware(correct)
+	c.Assert(r.GetNotFoundMiddleware(), Equals, correct)
 }
 
-func (*TestMiddleware) NewHandler(http.Handler) (http.Handler, error) {
-	return nil, nil
+type TestMiddleware struct {
+	Field string
+	next  http.Handler
+}
+
+func (*TestMiddleware) NewHandler(next http.Handler) (http.Handler, error) {
+	return &TestMiddleware{next: next}, nil
+}
+
+func (*TestMiddleware) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 }
 
 func GetSpec() *MiddlewareSpec {

--- a/proxy/mux_test.go
+++ b/proxy/mux_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"reflect"
 	"testing"
 	"time"
 
@@ -1034,7 +1035,7 @@ func (s *ServerSuite) TestGetStats(c *C) {
 }
 
 func (s *ServerSuite) TestNotFound(c *C) {
-	e := httptest.NewUnstartedServer(new(NotFound))
+	e := httptest.NewUnstartedServer(new(DefaultNotFound))
 	e.Start()
 	defer e.Close()
 
@@ -1042,6 +1043,14 @@ func (s *ServerSuite) TestNotFound(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(re.StatusCode, Equals, http.StatusNotFound)
 	c.Assert(re.Header.Get("Content-Type"), Equals, "application/json")
+}
+
+func (s *ServerSuite) TestCustomNotFound(c *C) {
+	st := stapler.New()
+	m, err := New(s.lastId, st, Options{NotFoundMiddleware: &appender{append: "Custom Not Found handler"}})
+	c.Assert(err, IsNil)
+	t := reflect.TypeOf(m.router.NotFound)
+	c.Assert(t.String(), Equals, "*proxy.appender")
 }
 
 func GETResponse(c *C, url string, opts ...testutils.ReqOption) string {

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -6,10 +6,10 @@ import (
 	"os"
 	"time"
 
-	"github.com/mailgun/vulcand/engine"
-
 	"github.com/mailgun/vulcand/Godeps/_workspace/src/github.com/mailgun/metrics"
 	"github.com/mailgun/vulcand/Godeps/_workspace/src/github.com/mailgun/timetools"
+	"github.com/mailgun/vulcand/engine"
+	"github.com/mailgun/vulcand/plugin"
 )
 
 type Proxy interface {
@@ -47,14 +47,15 @@ type Proxy interface {
 }
 
 type Options struct {
-	MetricsClient   metrics.Client
-	DialTimeout     time.Duration
-	ReadTimeout     time.Duration
-	WriteTimeout    time.Duration
-	MaxHeaderBytes  int
-	DefaultListener *engine.Listener
-	Files           []*FileDescriptor
-	TimeProvider    timetools.TimeProvider
+	MetricsClient      metrics.Client
+	DialTimeout        time.Duration
+	ReadTimeout        time.Duration
+	WriteTimeout       time.Duration
+	MaxHeaderBytes     int
+	DefaultListener    *engine.Listener
+	Files              []*FileDescriptor
+	TimeProvider       timetools.TimeProvider
+	NotFoundMiddleware plugin.Middleware
 }
 
 type NewProxyFn func(id int) (Proxy, error)

--- a/proxy/srv.go
+++ b/proxy/srv.go
@@ -297,7 +297,7 @@ func scopedHandler(scope string, proxy http.Handler) (http.Handler, error) {
 		return proxy, nil
 	}
 	mux := route.NewMux()
-	mux.NotFound = &NotFound{}
+	mux.NotFound = &DefaultNotFound{}
 	if err := mux.Handle(scope, proxy); err != nil {
 		return nil, err
 	}

--- a/service/service.go
+++ b/service/service.go
@@ -307,6 +307,7 @@ func (s *Service) newProxy(id int) (proxy.Proxy, error) {
 				Address: fmt.Sprintf("%s:%d", s.options.Interface, s.options.Port),
 			},
 		},
+		NotFoundMiddleware: s.registry.GetNotFoundMiddleware(),
 	})
 }
 


### PR DESCRIPTION
WHAT:
    1. Inside mux.go is a NotFound http.Handler that is used
       as the catch-all handler for requests that do not
       match any route.
    2. Repeatedly, we face situations where we want to know
       such requests and act on them (i.e. either throw a
       friendlier 404 Not Found page, or redirect them,
       or audit/log them to find missing/erraneous routes
       in our system.
    3. This is distinctly different from using the CircuitBreaker
       that only operates on routes that exist, but fail.

HOW:
    1. mux.go already has a NotFound handler, which I renamed to
       DefaultNotFound (for clarity should anyone read the code in
       the future and try to make sense of where the default
       one resides.)
    2. I then modified proxy.Options to hold a Middleware that could
       be set by the caller (service.go who instantiates mux router)
    3. service.go itself obtains this middleware from Registry which
       also holds all MiddlewareSpecs.
    4. I added methods to the registry to add/get the default middleware.

Wrote some tests to go along with the changes where necessary.

WHY NOT:
    1. Why not use etcd/engine? - Two reasons: Major one being time.
       I need this change to use vulcand ASAP. However, the major
       reason was because I need a NotFound handler when routes are
       failing - i.e. waiting for etcd to SET a middleware would
       be a point of failure. Given that I'm already compiling vulcan
       using vbundle, this seemed like a reliable way to ensure I have
       something in there, if all else fails.

    2. Why not pass a MiddlewareSpec, instead of Middleware? -
       Mainly because instantiating middlewares requires some
       parameters - which for other middlewares are obtained from
       etcd/engine. However, this middleware must be instantiated
       and ready to go with as little ceremony as possible, in order
       for it to be the catch-all default handler.

FUTURE IMPROVEMENTS:
    1. I may add an etcd or engine-based path as well. But we'll
       need to discuss a new key/namespace where we can add
       "default" or "catch-all" middlewares and write
       logic around injecting them.