### PR TITLE
Add entrypoint to dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
 FROM golang:1.4-onbuild
 EXPOSE 8181 8182
 RUN make install
+ENTRYPOINT ["/go/bin/vulcand"]


### PR DESCRIPTION
Let user to set command line options without having to know where is bin.
It's really useful for a big scale deploy and upgrade.