### PR TITLE
Revendor mailgun/oxy

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -58,43 +58,43 @@
 		},
 		{
 			"ImportPath": "github.com/mailgun/oxy/cbreaker",
-			"Rev": "563343dd5c1f1997846c85e353fbf81708982ab5"
+			"Rev": "946eb4e5bac9f322929ee4e5b14b7d08020b14e6"
 		},
 		{
 			"ImportPath": "github.com/mailgun/oxy/connlimit",
-			"Rev": "563343dd5c1f1997846c85e353fbf81708982ab5"
+			"Rev": "946eb4e5bac9f322929ee4e5b14b7d08020b14e6"
 		},
 		{
 			"ImportPath": "github.com/mailgun/oxy/forward",
-			"Rev": "563343dd5c1f1997846c85e353fbf81708982ab5"
+			"Rev": "946eb4e5bac9f322929ee4e5b14b7d08020b14e6"
 		},
 		{
 			"ImportPath": "github.com/mailgun/oxy/memmetrics",
-			"Rev": "563343dd5c1f1997846c85e353fbf81708982ab5"
+			"Rev": "946eb4e5bac9f322929ee4e5b14b7d08020b14e6"
 		},
 		{
 			"ImportPath": "github.com/mailgun/oxy/ratelimit",
-			"Rev": "563343dd5c1f1997846c85e353fbf81708982ab5"
+			"Rev": "946eb4e5bac9f322929ee4e5b14b7d08020b14e6"
 		},
 		{
 			"ImportPath": "github.com/mailgun/oxy/roundrobin",
-			"Rev": "563343dd5c1f1997846c85e353fbf81708982ab5"
+			"Rev": "946eb4e5bac9f322929ee4e5b14b7d08020b14e6"
 		},
 		{
 			"ImportPath": "github.com/mailgun/oxy/stream",
-			"Rev": "563343dd5c1f1997846c85e353fbf81708982ab5"
+			"Rev": "946eb4e5bac9f322929ee4e5b14b7d08020b14e6"
 		},
 		{
 			"ImportPath": "github.com/mailgun/oxy/testutils",
-			"Rev": "563343dd5c1f1997846c85e353fbf81708982ab5"
+			"Rev": "946eb4e5bac9f322929ee4e5b14b7d08020b14e6"
 		},
 		{
 			"ImportPath": "github.com/mailgun/oxy/trace",
-			"Rev": "563343dd5c1f1997846c85e353fbf81708982ab5"
+			"Rev": "946eb4e5bac9f322929ee4e5b14b7d08020b14e6"
 		},
 		{
 			"ImportPath": "github.com/mailgun/oxy/utils",
-			"Rev": "563343dd5c1f1997846c85e353fbf81708982ab5"
+			"Rev": "946eb4e5bac9f322929ee4e5b14b7d08020b14e6"
 		},
 		{
 			"ImportPath": "github.com/mailgun/predicate",

--- a/Godeps/_workspace/src/github.com/mailgun/oxy/forward/fwd.go
+++ b/Godeps/_workspace/src/github.com/mailgun/oxy/forward/fwd.go
@@ -122,6 +122,8 @@ func (f *Forwarder) copyRequest(req *http.Request, u *url.URL) *http.Request {
 	outReq.URL.Opaque = req.RequestURI
 	// raw query is already included in RequestURI, so ignore it to avoid dupes
 	outReq.URL.RawQuery = ""
+	// Go doesn't implicitly pass the host header unless you set Host on the request
+	outReq.Host = u.Host
 
 	outReq.Proto = "HTTP/1.1"
 	outReq.ProtoMajor = 1

--- a/Godeps/_workspace/src/github.com/mailgun/oxy/forward/rewrite.go
+++ b/Godeps/_workspace/src/github.com/mailgun/oxy/forward/rewrite.go
@@ -32,10 +32,15 @@ func (rw *HeaderRewriter) Rewrite(req *http.Request) {
 		req.Header.Set(XForwardedProto, "http")
 	}
 
-	if req.Host != "" {
+	if xfh := req.Header.Get(XForwardedHost); xfh != "" && rw.TrustForwardHeader {
+		req.Header.Set(XForwardedHost, xfh)
+	} else if req.Host != "" {
 		req.Header.Set(XForwardedHost, req.Host)
 	}
-	req.Header.Set(XForwardedServer, rw.Hostname)
+
+	if rw.Hostname != "" {
+		req.Header.Set(XForwardedServer, rw.Hostname)
+	}
 
 	// Remove hop-by-hop headers to the backend.  Especially important is "Connection" because we want a persistent
 	// connection, regardless of what the client sent to us.

--- a/Godeps/_workspace/src/github.com/mailgun/oxy/stream/stream.go
+++ b/Godeps/_workspace/src/github.com/mailgun/oxy/stream/stream.go
@@ -46,8 +46,8 @@ import (
 )
 
 const (
-	DefaultMemBodyBytes = // Store up to 1MB in RAM
-	1048576
+	// Store up to 1MB in RAM
+	DefaultMemBodyBytes = 1048576
 	// No limit by default
 	DefaultMaxBodyBytes = -1
 	// Maximum retry attempts

--- a/Godeps/_workspace/src/github.com/mailgun/oxy/utils/netutils_test.go
+++ b/Godeps/_workspace/src/github.com/mailgun/oxy/utils/netutils_test.go
@@ -27,7 +27,7 @@ func (s *NetUtilsSuite) TestCopyUrl(c *C) {
 		User:     &url.Userinfo{},
 	}
 	urlB := CopyURL(urlA)
-	c.Assert(urlB, DeepEquals, urlB)
+	c.Assert(urlB, DeepEquals, urlA)
 	urlB.Scheme = "https"
 	c.Assert(urlB, Not(DeepEquals), urlA)
 }


### PR DESCRIPTION
Fix overwrite of X-Forwarded-Host when trusting forward header

I'm having trouble getting the `trace_test` to pass - both before and after

```
=== RUN TestTrace

----------------------------------------------------------------------
FAIL: trace_test.go:33: TraceSuite.TestGoodAddr

trace_test.go:52:
    c.Assert(err, IsNil)
... value *net.OpError = &net.OpError{Op:"dial", Net:"unixgram", Addr:(*net.UnixAddr)(0xc20800ac20), Err:0x2} ("dial unixgram /dev/log: no such file or directory")


----------------------------------------------------------------------
FAIL: trace_test.go:132: TraceSuite.TestNewFromCLI

trace_test.go:148:
    app.Run([]string{"test", "--addr=syslog:///dev/log?sev=INFO&f=MAIL", "--reqHeader=X-A", "--reqHeader=X-B", "--respHeader=X-C", "--respHeader=X-D"})
trace_test.go:139:
    c.Assert(out, NotNil)
... value *trace.Trace = (*trace.Trace)(nil) (<nil>)

OOPS: 3 passed, 2 FAILED
```