### PR TITLE
InitWithConfig needs an explicit severity

### DIFF
--- a/service/service.go
+++ b/service/service.go
@@ -67,7 +67,7 @@ func NewService(options Options, registry *plugin.Registry) *Service {
 }
 
 func (s *Service) Start() error {
-	log.InitWithConfig(log.Config{Name: s.options.Log})
+	log.InitWithConfig(log.Config{Name: s.options.Log, Severity: "ERROR"})
 
 	log.SetSeverity(s.options.LogSeverity.s)
 


### PR DESCRIPTION
Otherwise logger creation fails on severity parsing
And hence there are no logs whatsoever