### PR TITLE
Ability to disable Default listener

### DIFF
--- a/service/options.go
+++ b/service/options.go
@@ -40,6 +40,8 @@ type Options struct {
 
 	StatsdAddr   string
 	StatsdPrefix string
+
+	DefaultListener bool
 }
 
 type SeverityFlag struct {
@@ -123,6 +125,8 @@ func ParseCommandLine() (options Options, err error) {
 
 	flag.StringVar(&options.StatsdPrefix, "statsdPrefix", "", "Statsd prefix will be appended to the metrics emitted by this instance")
 	flag.StringVar(&options.StatsdAddr, "statsdAddr", "", "Statsd address in form of 'host:port'")
+
+	flag.BoolVar(&options.DefaultListener, "default-listener", true, "Enables the default listener on startup (Default value: true)")
 
 	flag.Parse()
 	options, err = validateOptions(options)

--- a/service/service.go
+++ b/service/service.go
@@ -299,12 +299,12 @@ func (s *Service) reportSystemMetrics() {
 
 func (s *Service) newProxy(id int) (proxy.Proxy, error) {
 	return proxy.New(id, s.stapler, proxy.Options{
-		MetricsClient:  s.metricsClient,
-		DialTimeout:    s.options.EndpointDialTimeout,
-		ReadTimeout:    s.options.ServerReadTimeout,
-		WriteTimeout:   s.options.ServerWriteTimeout,
-		MaxHeaderBytes: s.options.ServerMaxHeaderBytes,
-		DefaultListener: constructDefaultListener(s.options),
+		MetricsClient:      s.metricsClient,
+		DialTimeout:        s.options.EndpointDialTimeout,
+		ReadTimeout:        s.options.ServerReadTimeout,
+		WriteTimeout:       s.options.ServerWriteTimeout,
+		MaxHeaderBytes:     s.options.ServerMaxHeaderBytes,
+		DefaultListener:    constructDefaultListener(s.options),
 		NotFoundMiddleware: s.registry.GetNotFoundMiddleware(),
 	})
 }
@@ -339,7 +339,7 @@ func (s *Service) startApi(file *proxy.FileDescriptor) error {
 	return s.apiServer.ListenAndServe()
 }
 
-func constructDefaultListener(options Options) (*engine.Listener) {
+func constructDefaultListener(options Options) *engine.Listener {
 	if options.DefaultListener {
 		return &engine.Listener{
 			Id:       "DefaultListener",

--- a/service/service.go
+++ b/service/service.go
@@ -304,14 +304,7 @@ func (s *Service) newProxy(id int) (proxy.Proxy, error) {
 		ReadTimeout:    s.options.ServerReadTimeout,
 		WriteTimeout:   s.options.ServerWriteTimeout,
 		MaxHeaderBytes: s.options.ServerMaxHeaderBytes,
-		DefaultListener: &engine.Listener{
-			Id:       "DefaultListener",
-			Protocol: "http",
-			Address: engine.Address{
-				Network: "tcp",
-				Address: fmt.Sprintf("%s:%d", s.options.Interface, s.options.Port),
-			},
-		},
+		DefaultListener: constructDefaultListener(s.options),
 		NotFoundMiddleware: s.registry.GetNotFoundMiddleware(),
 	})
 }
@@ -344,6 +337,20 @@ func (s *Service) startApi(file *proxy.FileDescriptor) error {
 
 	s.apiServer = manners.NewWithOptions(manners.Options{Server: server, Listener: listener})
 	return s.apiServer.ListenAndServe()
+}
+
+func constructDefaultListener(options Options) (*engine.Listener) {
+	if options.DefaultListener {
+		return &engine.Listener{
+			Id:       "DefaultListener",
+			Protocol: "http",
+			Address: engine.Address{
+				Network: "tcp",
+				Address: fmt.Sprintf("%s:%d", options.Interface, options.Port),
+			},
+		}
+	}
+	return nil
 }
 
 func execPath() (string, error) {


### PR DESCRIPTION
This is a backwards compatible change that allows you to disable the default listener from being created, by forcing a boolean parameter to false.
